### PR TITLE
Epicure optimizations for mesh read-in

### DIFF
--- a/.github/workflows/CI_parallel_MU.yml
+++ b/.github/workflows/CI_parallel_MU.yml
@@ -8,9 +8,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   # Comment lines 10-13 to deactivate automatic running until Metis webpage is online again.
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -339,6 +339,31 @@ jobs:
       #   if: '!cancelled()'
 
 #
+# 0) Uniform Flow
+# ---------------
+
+      - name: Build NSUniformFlow
+        working-directory: ./Solver/test/NavierStokes/UniformFlow/SETUP
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSUniformFlow_parallel
+        working-directory: ./Solver/test/NavierStokes/UniformFlow
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          mpiexec -n 3 ./horses3d.ns UniformFlow.control
+        if: '!cancelled()'
+
+      - name: Run NSUniformFlow_serial
+        working-directory: ./Solver/test/NavierStokes/UniformFlow
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          mpiexec -n 1 ./horses3d.ns UniformFlow.control
+        if: '!cancelled()'
+
+#
 # 1) CYLINDER
 # -----------
 

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -363,14 +363,14 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/UniformFlow
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 3 ./horses3d.ns UniformFlow.control
+          mpiexec -n 3 ./horses3d.ns UniformFlow_HDF5.control
         if: '!cancelled()'
 
       - name: Run NSUniformFlow_serial
         working-directory: ./Solver/test/NavierStokes/UniformFlow
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 1 ./horses3d.ns UniformFlow.control
+          mpiexec -n 1 ./horses3d.ns UniformFlow_HDF5.control
         if: '!cancelled()'
 
 #

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -8,9 +8,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   # Comment lines 10-13 to deactivate automatic running until Metis webpage is online again.
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -30,8 +30,9 @@ jobs:
         mode: ['RELEASE']
         comm: ['PARALLEL']
         enable_threads: ['NO']
+        hdf5: ['YES']
         
-    name: NS - ${{ matrix.compiler }} - ${{ matrix.mode }} - ${{ matrix.comm }} - ${{ matrix.enable_threads }}
+    name: NS - ${{ matrix.compiler }} - ${{ matrix.mode }} - ${{ matrix.comm }} - OpenMP = ${{ matrix.enable_threads }}
     
     env:
       METIS_HOME:  /home/runner/work/horses3d-gpu/horses3d-gpu/metis-5.1.0/build/Linux-x86_64
@@ -41,6 +42,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      - name: Install hdf5 (only gfortran)
+        if: (matrix.compiler == 'gfortran')
+        run: |
+          sudo apt-get update
+          sudo apt install libhdf5-dev
+          dpkg -L libhdf5-dev 
+          echo "HDF5_ROOT="/usr/lib/x86_64-linux-gnu/hdf5/serial/"" >> $GITHUB_ENV  
 
       # IF COMPILER = GFORTRAN -> INSTALL OPEN-MPI #
       - name: install openmpi

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -30,6 +30,7 @@ jobs:
         mode: ['RELEASE']
         comm: ['PARALLEL']
         enable_threads: ['NO']
+        mkl: ['NO']
         hdf5: ['YES']
         
     name: NS - ${{ matrix.compiler }} - ${{ matrix.mode }} - ${{ matrix.comm }} - OpenMP = ${{ matrix.enable_threads }}
@@ -142,8 +143,8 @@ jobs:
         working-directory: ./Solver
         run: |
          source /opt/intel/oneapi/setvars.sh || true
-         make allclean MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-         make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+         make allclean MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+         make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
 
 
 # GRC 30/10/2025 - DEACTIVATE EULER TEST CASES - NOT WORKING IN GPU         
@@ -355,7 +356,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/UniformFlow/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSUniformFlow_parallel
@@ -380,7 +381,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/Cylinder/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSCylinder
@@ -455,7 +456,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/CylinderSmagorinsky/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSCylinderSmagorinsky
@@ -473,7 +474,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/CylinderWALE/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSCylinderWALE
@@ -491,7 +492,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/CylinderVreman/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSCylinderVreman
@@ -509,7 +510,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/CylinderChandrasekarRoe/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run NSCylinderChandrasekarRoe
@@ -527,7 +528,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/TaylorGreen/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run TaylorGreen
@@ -686,7 +687,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/DualTimeStepping/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
 
       - name: Run DualTimeStepping
@@ -826,7 +827,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/IBM_Cylinder/SETUP
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
         if: '!cancelled()'
      
       - name: Run IBM_Cylinder

--- a/.github/workflows/CI_serial_MU.yml
+++ b/.github/workflows/CI_serial_MU.yml
@@ -8,9 +8,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   # Comment lines 10-13 to deactivate automatic running until Metis webpage is online again.
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Solver/configure
+++ b/Solver/configure
@@ -40,6 +40,7 @@ TEST_CASES="./Euler/BoxAroundCircle \
             ./Euler/JFNK \
             ./Euler/TaylorGreenKEPEC \
             ./Euler/Cylinder_ErrorEstimation_pAdaptationRL \
+            ./NavierStokes/UniformFlow \
             ./NavierStokes/Convergence \
             ./NavierStokes/Convergence_energy \
             ./NavierStokes/Convergence_entropy \

--- a/Solver/src/libs/mesh/MeshPartitioning.f90
+++ b/Solver/src/libs/mesh/MeshPartitioning.f90
@@ -93,120 +93,78 @@ module MeshPartitioning
 !
 !////////////////////////////////////////////////////////////////////////
 !
-     subroutine GetNodesPartition(mesh, no_of_domains, elementsDomain, partitions)
-        use Utilities, only: Qsort
-        implicit none
-        type(HexMesh), intent(in)              :: mesh
-        integer,       intent(in)              :: no_of_domains
-        integer,       intent(in)              :: elementsDomain(mesh % no_of_elements)
-        type(PartitionedMesh_t), intent(inout) :: partitions(no_of_domains)   
-!
-!       ---------------
-!       Local Variables
-!       ---------------
-!
-        integer              :: nvertex
-        integer              :: i
-        integer              :: j
-        integer              :: k
-        integer              :: ipoint
-        integer              :: jpoint
-        integer              :: idomain
-        integer              :: npoints
-        integer              :: ielem
-        logical              :: isnewpoint
-        logical              :: meshIsHOPR
-        integer, allocatable :: points(:)
-        integer, allocatable :: HOPRpoints(:)
-
-        nvertex = 8
-        
-        meshIsHOPR = allocated (mesh % HOPRnodeIDs)
-        
-        do idomain=1,no_of_domains
-!
-!       Get the number of elements for the partition
-!       --------------------------------------------
-        partitions(idomain)%no_of_elements = count(elementsDomain == idomain)
-        allocate(partitions(idomain)%elementIDs(partitions(idomain)%no_of_elements))
-!
-!       This will store the partition nodes (allocated as 8 * no_of_elements)
-!       ---------------------------------------------------------------------
-        allocate(points(nvertex*partitions(idomain)%no_of_elements))
-        points = 0
-        if (meshIsHOPR) then
-            allocate(HOPRpoints(nvertex*partitions(idomain)%no_of_elements))
-            HOPRpoints = 0
-        end if
-!
-!       ****************************************
-!       Gather each partition nodes and elements      
-!       ****************************************
-!
-        k = 0
-        npoints = 0
-        do ielem=1,mesh % no_of_elements
-           if (elementsDomain(ielem) == idomain) then
-!
-!             Append a new element
-!             --------------------
-              k = k + 1
-              partitions(idomain)%elementIDs(k) = ielem
-!
-!             Append its nodes
-!             ----------------           
-              do j=1,nvertex
-!
-!                Get the node ID
-!                ---------------
-                 jpoint = mesh % elements(ielem) % nodeIDs(j)
-!
-!                Check if it is already stored
-!                -----------------------------
-                 isnewpoint = .true.
-                 do i=1,npoints
-                    ipoint = points(i)
-                    if (jpoint == ipoint) then
-                       isnewpoint = .false.
-                       exit
-                    end if
-                 end do
-!
-!                Store the node
-!                --------------      
-                 if (isnewpoint) then
-                    npoints = npoints + 1
-                    points(npoints) = jpoint
-                    if (meshIsHOPR) HOPRpoints(npoints) = mesh % HOPRnodeIDs(jpoint)
-                 end if                  
-              end do
-            end if      
+      subroutine GetNodesPartition(mesh, no_of_domains, elementsDomain, partitions)
+         use Utilities, only: Qsort
+         implicit none
+     
+         type(HexMesh), intent(in)              :: mesh
+         integer,       intent(in)              :: no_of_domains
+         integer,       intent(in)              :: elementsDomain(mesh%no_of_elements)
+         type(PartitionedMesh_t), intent(inout) :: partitions(no_of_domains)
+     
+         integer              :: nvertex, i, j, k, ipoint, jpoint
+         integer              :: idomain, npoints, ielem
+         logical              :: isnewpoint, meshIsHOPR
+         integer, allocatable :: points(:), HOPRpoints(:)
+         logical, allocatable :: mask(:)  ! Mask array for node uniqueness
+         integer              :: max_nodes
+     
+         nvertex = 8
+         meshIsHOPR = allocated(mesh%HOPRnodeIDs)
+         max_nodes = 0
+         do ielem = 1, mesh%no_of_elements
+            max_nodes = max(maxval(mesh%elements(ielem)%nodeIDs(:)), max_nodes)
          end do
-!
-!        Put the nodeIDs into the partitions structure
-!        ---------------------------------------------      
-         allocate(partitions(idomain)%nodeIDs(npoints))
-         partitions(idomain)%nodeIDs(:) = points(1:npoints)
-         
-         if (meshIsHOPR) then
-            allocate(partitions(idomain)%HOPRnodeIDs(npoints))
-            partitions(idomain)%HOPRnodeIDs(:) = HOPRpoints(1:npoints)
-         end if
-!
-!        Sort the nodeIDs to read the mesh file accordingly (only needed for SpecMesh)
-!        --------------------------------------------------
-         if (.not. meshIsHOPR) call Qsort(partitions(idomain)%nodeIDs)
 
-         partitions(idomain)%no_of_nodes = npoints
-!
-!        ****
-!        Free
-!        ****
-!
-         deallocate(points)
-         safedeallocate(HOPRpoints)
-      end do
-
+         allocate(mask(max_nodes))  ! One-time allocation
+     
+         do idomain = 1, no_of_domains
+             partitions(idomain)%no_of_elements = count(elementsDomain == idomain)
+             allocate(partitions(idomain)%elementIDs(partitions(idomain)%no_of_elements))
+             allocate(points(nvertex * partitions(idomain)%no_of_elements))
+             points = 0
+     
+             if (meshIsHOPR) then
+                 allocate(HOPRpoints(nvertex * partitions(idomain)%no_of_elements))
+                 HOPRpoints = 0
+             end if
+     
+             mask = .false.  ! Reset mask for new domain
+             k = 0
+             npoints = 0
+             do ielem = 1, mesh%no_of_elements
+                 if (elementsDomain(ielem) == idomain) then
+                     k = k + 1
+                     partitions(idomain)%elementIDs(k) = ielem
+                     do j = 1, nvertex
+                         jpoint = mesh%elements(ielem)%nodeIDs(j)
+                         if (.not. mask(jpoint)) then
+                             npoints = npoints + 1
+                             points(npoints) = jpoint
+                             mask(jpoint) = .true.
+                             if (meshIsHOPR) HOPRpoints(npoints) = mesh%HOPRnodeIDs(jpoint)
+                         end if
+                     end do
+                 end if
+             end do
+     
+             allocate(partitions(idomain)%nodeIDs(npoints))
+             partitions(idomain)%nodeIDs = points(1:npoints)
+     
+             if (meshIsHOPR) then
+                 allocate(partitions(idomain)%HOPRnodeIDs(npoints))
+                 partitions(idomain)%HOPRnodeIDs = HOPRpoints(1:npoints)
+             end if
+     
+             if (.not. meshIsHOPR) call Qsort(partitions(idomain)%nodeIDs)
+     
+             partitions(idomain)%no_of_nodes = npoints
+     
+             deallocate(points)
+             if (allocated(HOPRpoints)) deallocate(HOPRpoints)
+         end do
+     
+         deallocate(mask)
      end subroutine GetNodesPartition
 !
 !////////////////////////////////////////////////////////////////////////

--- a/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
+++ b/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
@@ -143,6 +143,7 @@ contains
       integer, allocatable       :: HOPRNodeMap(:)       ! Map from the global node index of HORSES3D to the global node index of HOPR
       real(kind=RP), allocatable :: TempNodes(:,:)       ! Nodes read from file to be exported to self % nodes
       logical                    :: CurveCondition
+      integer, allocatable       :: NodeToHOPRMap(:)      
       !---------------------------------------------------------------
       
 !
@@ -255,10 +256,8 @@ contains
          ! Read nodeIDs and add them to the self%nodes array
          DO k = 1, NODES_PER_ELEMENT
             HOPRNodeID = ElemInfo(ELEM_FirstNodeInd,l) + HCornerMap(k)
-            
             corners(:,k) = NodeCoords(:,HOPRNodeID) / Lref
-            
-            call AddToNodeMap (TempNodes , HOPRNodeMap, corners(:,k), GlobalNodeIDs(HOPRNodeID), nodeIDs(k))
+            call AddToNodeMap(TempNodes , HOPRNodeMap, NodeToHOPRMap, corners(:,k), GlobalNodeIDs(HOPRNodeID), nodeIDs(k))
          END DO
          
          do k = 1, FACES_PER_ELEMENT
@@ -1241,9 +1240,10 @@ contains
       
       allocate (TempNodes(3,nUniqueNodes))
       allocate (HOPRNodeMap(nUniqueNodes))
-      
-      TempNodes   = 0._RP
-      HOPRNodeMap = 0
+      allocate(NodeToHOPRMap(nUniqueNodes))
+      NodeToHOPRMap = -1
+      TempNodes     = 0._RP
+      HOPRNodeMap   = 0
       
    end subroutine InitNodeMap
    
@@ -1253,11 +1253,13 @@ contains
 !  ----------------------------------------------------------------
 !  Add a new entry to the node map
 !  ----------------------------------------------------------------
-   subroutine AddToNodeMap (TempNodes , HOPRNodeMap, newnode, HOPRGlobalID,nodeID)
+
+   subroutine AddToNodeMap(TempNodes , HOPRNodeMap, NodeToHOPRMap, newnode, HOPRGlobalID,nodeID)
       implicit none
       !--------------------------------------------
       real(kind=RP), intent(inout) :: TempNodes(:,:)
       integer      , intent(inout) :: HOPRNodeMap(:)
+      integer      , intent(inout) :: NodeToHOPRMap(:)
       real(kind=RP), intent(in)    :: newnode(3)
       integer      , intent(in)    :: HOPRGlobalID
       integer      , intent(out)   :: nodeID          ! Node ID in HORSES3D!
@@ -1265,21 +1267,20 @@ contains
       integer       :: i         ! Counter
       !--------------------------------------------
       
-      do i = 1, idx
-         if (HOPRGlobalID == HOPRNodeMap(i)) then
-            nodeID = i
-            return
-         end if
-      end do
-      
+
+      if (NodeToHOPRMap(HOPRGlobalID) .ne. -1 ) then
+         nodeID = NodeToHOPRMap(HOPRGlobalID)
+         return
+      end if
+
       idx = idx + 1
       nodeID = idx
-      
-      TempNodes(:,idx) = newnode
-      HOPRNodeMap(idx) = HOPRGlobalID
-      
+      TempNodes(:,idx)            = newnode
+      HOPRNodeMap(idx)            = HOPRGlobalID
+      NodeToHOPRMap(HOPRGlobalID) = idx
    end subroutine AddToNodeMap
 
+   
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
@@ -1318,6 +1319,7 @@ contains
       
       deallocate (TempNodes)
       deallocate (HOPRNodeMap)
+      deallocate(NodeToHOPRMap)
       
    end subroutine FinishNodeMap
 

--- a/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
+++ b/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
@@ -245,7 +245,7 @@ contains
       self % Ny = Ny
       self % Nz = Nz
      
-      call InitNodeMap (TempNodes , HOPRNodeMap, nUniqueNodes)
+      call InitNodeMap (TempNodes , HOPRNodeMap, NodeToHOPRMap, nUniqueNodes)
       
 !      
 !     Now we construct the elements
@@ -1230,11 +1230,12 @@ contains
 !  Initialize: allocating to the nUniqueNodes.. 
 !     In general, nCornerNodes <= nUniqueNodes
 !  ----------------------------------------------------------------
-   subroutine InitNodeMap (TempNodes , HOPRNodeMap, nUniqueNodes)
+   subroutine InitNodeMap (TempNodes , HOPRNodeMap, NodeToHOPRMap, nUniqueNodes)
       implicit none
       !--------------------------------------------
       real(kind=RP), allocatable, intent(inout) :: TempNodes(:,:)
       integer      , allocatable, intent(inout) :: HOPRNodeMap(:)
+      integer      , allocatable, intent(inout) :: NodeToHOPRMap(:)
       integer                   , intent(in)    :: nUniqueNodes
       !--------------------------------------------
       

--- a/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
+++ b/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
@@ -348,7 +348,7 @@ contains
          
       end do      ! l = 1, numberOfElements
       
-      call FinishNodeMap (TempNodes , HOPRNodeMap, self % nodes, self % HOPRnodeIDs)
+      call FinishNodeMap (TempNodes , HOPRNodeMap, NodeToHOPRMap, self % nodes, self % HOPRnodeIDs)
       
       
 !     Construct the element faces

--- a/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
+++ b/Solver/src/libs/mesh/Read_HDF5Mesh_HOPR.f90
@@ -1288,11 +1288,12 @@ contains
 !  ----------------------------------------------------------------
 !  Construct nodes of mesh and deallocate temporal arrays
 !  ----------------------------------------------------------------
-   subroutine FinishNodeMap (TempNodes , HOPRNodeMap, nodes, HOPRnodeIDs)
+   subroutine FinishNodeMap (TempNodes , HOPRNodeMap, NodeToHOPRMap, nodes, HOPRnodeIDs)
       implicit none
       !--------------------------------------------
       real(kind=RP), allocatable, intent(inout) :: TempNodes(:,:)
       integer      , allocatable, intent(inout) :: HOPRNodeMap(:)
+      integer      , allocatable, intent(inout) :: NodeToHOPRMap(:)
       type(Node)   , allocatable, intent(inout) :: nodes(:)
       integer      , allocatable, intent(inout) :: HOPRnodeIDs(:) ! The final node map that is stored in the mesh type
       !--------------------------------------------

--- a/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
@@ -1,0 +1,404 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#if defined(NAVIERSTOKES)
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#if defined(CAHNHILLIARD)
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            class(HexMesh)                      :: mesh
+#if defined(NAVIERSTOKES)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#if defined(CAHNHILLIARD)
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#if defined(NAVIERSTOKES)
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#if defined(CAHNHILLIARD)
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#if defined(NAVIERSTOKES)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#if defined(CAHNHILLIARD)
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refValues_ % AOATheta*(PI/180.0_RP)
+            phi   = refValues_ % AOAPhi*(PI/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          Ny => mesh % elements(eID) % Nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*COS(phi)
+                  v  = qq*sin(theta)*COS(phi)
+                  w  = qq*SIN(phi)
+      
+                  Q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  Q(2) = Q(1)*u
+                  Q(3) = Q(1)*v
+                  Q(4) = Q(1)*w
+                  Q(5) = p/(gamma - 1._RP) + 0.5_RP*Q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % Q(:,i,j,k) = Q 
+               end do;        end do;        end do
+               end associate
+!
+!              -------------------------------------------------
+!              Perturb mean flow in the expectation that it will
+!              relax back to the mean flow
+!              -------------------------------------------------
+!
+               mesh % elements(eID) % storage % Q(1,3,3,3) = 1.05_RP*mesh % elements(eID) % storage % Q(1,3,3,3)
+
+            end do
+
+            end associate
+#endif
+         end subroutine UserDefinedInitialCondition
+#if defined(NAVIERSTOKES)
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+!
+!           -------------------------------------------------
+!           Used to define an user defined boundary condition
+!           -------------------------------------------------
+!
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, GetGradients, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            use VariableConversion, only: GetGradientValues_f
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            procedure(GetGradientValues_f)     :: GetGradients
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, U_x, U_y, U_z)
+!
+!           --------------------------------------------------------
+!           Used to define a Neumann user defined boundary condition
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: U_x(NGRAD)
+            real(kind=RP), intent(inout)  :: U_y(NGRAD)
+            real(kind=RP), intent(inout)  :: U_z(NGRAD)
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called at the output interval to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+#if defined(NAVIERSTOKES)
+            use MonitorsClass
+#endif
+            IMPLICIT NONE
+            class(HexMesh)               :: mesh
+            real(kind=RP)                :: time
+            real(kind=RP)                :: dt
+#if defined(NAVIERSTOKES)
+            type(Monitor_t), intent(in) :: monitors
+#else
+            logical, intent(in) :: monitors
+#endif
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#if defined(NAVIERSTOKES)
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+            S    = 0.0_RP
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#if defined(NAVIERSTOKES)
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#if defined(CAHNHILLIARD)
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            class(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#if defined(NAVIERSTOKES)
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#if defined(CAHNHILLIARD)
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            INTEGER                            :: numberOfFailures
+            CHARACTER(LEN=29)                  :: testName           = "27 element uniform flow tests"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            real(kind=RP)                      :: qq, u, v, w, p, Q(NCONS), theta, phi
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+!
+!           -----------------------------------------------------------------------
+!           Expected Values. Note they will change if the run parameters change and
+!           when the eigenvalue computation for the time step is fixed. These 
+!           results are for the Mach 0.5 and rusanov solvers.
+!           -----------------------------------------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            INTEGER                            :: expectedIterations(3:5) = [1821,3090,4164]
+            REAL(KIND=RP)                      :: expectedResidual(3:5)   = [9.7985624521602423E-011,&
+                                                                             9.7825050715404729E-011,&
+                                                                             9.7454147241309180E-011]
+            
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            N = mesh % elements(1) % Nxyz(1) ! This works here because all the elements have the same order
+            CALL FTAssertEqual(expectedValue= expectedIterations(N), &
+                               actualValue   =  iter, &
+                               msg           = "Number of time steps to tolerance")
+            CALL FTAssertEqual(expectedValue = expectedResidual(N), &
+                               actualValue   = maxResidual, &
+                               tol           = 1.d-3, &
+                               msg           = "Final maximum residual")
+            
+            ALLOCATE(QExpected(NCONS,0:N,0:N,0:N))
+            
+            maxError = 0.0_RP
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refValues_ % AOATheta*(PI/180.0_RP)
+            phi   = refValues_ % AOAPhi*(PI/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          Ny => mesh % elements(eID) % Nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*COS(phi)
+                  v  = qq*sin(theta)*COS(phi)
+                  w  = qq*SIN(phi)
+      
+                  Q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  Q(2) = Q(1)*u
+                  Q(3) = Q(1)*v
+                  Q(4) = Q(1)*w
+                  Q(5) = p/(gamma - 1._RP) + 0.5_RP*Q(1)*(u**2 + v**2 + w**2)
+
+                  QExpected(:,i,j,k) = Q 
+               end do;        end do;        end do
+               end associate
+               maxError = MAXVAL(ABS(QExpected - mesh % elements(eID) % storage % Q))
+            end do
+            end associate
+
+            CALL FTAssertEqual(expectedValue = 0.0_RP, &
+                               actualValue   = maxError, &
+                               tol           = 1.d-10, &
+                               msg           = "Maximum error")
+            
+            
+            CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is fixed."
+               WRITE(6,*) "      When that is done, re-compute the expected values and modify this procedure"
+               error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
@@ -308,23 +308,21 @@
 !           -----------------------------------------------------------------------
 !
 #if defined(NAVIERSTOKES)
-            INTEGER                            :: expectedIterations(3:5) = [1821,3090,4164]
-            REAL(KIND=RP)                      :: expectedResidual(3:5)   = [9.7985624521602423E-011,&
-                                                                             9.7825050715404729E-011,&
-                                                                             9.7454147241309180E-011]
+            INTEGER                            :: expectedIterations = 100
+            REAL(KIND=RP)                      :: expectedResidual = 0.0_RP
             
             CALL initializeSharedAssertionsManager
             sharedManager => sharedAssertionsManager()
             
-            N = mesh % elements(1) % Nxyz(1) ! This works here because all the elements have the same order
-            CALL FTAssertEqual(expectedValue= expectedIterations(N), &
+            CALL FTAssertEqual(expectedValue= expectedIterations, &
                                actualValue   =  iter, &
                                msg           = "Number of time steps to tolerance")
-            CALL FTAssertEqual(expectedValue = expectedResidual(N), &
+            CALL FTAssertEqual(expectedValue = expectedResidual, &
                                actualValue   = maxResidual, &
-                               tol           = 1.d-3, &
+                               tol           = 1.d-11, &
                                msg           = "Final maximum residual")
             
+            N = mesh % elements(1) % Nxyz(1) ! This works here because all the elements have the same order
             ALLOCATE(QExpected(NCONS,0:N,0:N,0:N))
             
             maxError = 0.0_RP

--- a/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
@@ -293,7 +293,6 @@
 !           Local variables
 !           ---------------
 !
-            INTEGER                            :: numberOfFailures
             CHARACTER(LEN=29)                  :: testName           = "27 element uniform flow tests"
             REAL(KIND=RP)                      :: maxError
             REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
@@ -305,7 +304,7 @@
 !           -----------------------------------------------------------------------
 !           Expected Values. Note they will change if the run parameters change and
 !           when the eigenvalue computation for the time step is fixed. These 
-!           results are for the Mach 0.5 and rusanov solvers.
+!           results are for the Mach 0.5 and Roe solver.
 !           -----------------------------------------------------------------------
 !
 #if defined(NAVIERSTOKES)

--- a/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/UniformFlow/SETUP/ProblemFile.f90
@@ -129,14 +129,6 @@
                   mesh % elements(eID) % storage % Q(:,i,j,k) = Q 
                end do;        end do;        end do
                end associate
-!
-!              -------------------------------------------------
-!              Perturb mean flow in the expectation that it will
-!              relax back to the mean flow
-!              -------------------------------------------------
-!
-               mesh % elements(eID) % storage % Q(1,3,3,3) = 1.05_RP*mesh % elements(eID) % storage % Q(1,3,3,3)
-
             end do
 
             end associate

--- a/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
+++ b/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
@@ -1,0 +1,22 @@
+/* Control file for the uniform flow test case */
+Flow equations        = NS
+mesh file name        = "../../TestMeshes/Box27.h5"
+partitioning          = SFC
+restart file name     = "RESULTS/Box27.hsol"
+solution file name    = "RESULTS/Box27_saved.hsol"
+restart               = .false.
+Polynomial order      = 5
+Number of time steps  = 100
+Output Interval       = 10
+Convergence tolerance = 1.d-10
+cfl                   = 0.4
+dcfl                  = 0.4
+mach number           = 0.5
+Reynolds number       = 100.0
+AOA theta             = 30.0
+AOA phi               = 30.0
+Riemann solver        = Roe
+
+#define boundary left__right__front__back__bottom__top
+   type = Inflow
+#end

--- a/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
+++ b/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
@@ -1,5 +1,6 @@
 /* Control file for the uniform flow test case */
 Flow equations        = NS
+simulation type       = time-accurate 
 mesh file name        = "../../TestMeshes/Box27.h5"
 partitioning          = SFC
 restart file name     = "RESULTS/Box27.hsol"

--- a/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
+++ b/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
@@ -13,8 +13,8 @@ cfl                   = 0.4
 dcfl                  = 0.4
 mach number           = 0.5
 Reynolds number       = 100.0
-AOA theta             = 0.0
-AOA phi               = 0.0
+AOA theta             = 30.0
+AOA phi               = 30.0
 Riemann solver        = Roe
 
 #define boundary left__right__front__back__bottom__top

--- a/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
+++ b/Solver/test/NavierStokes/UniformFlow/UniformFlow_HDF5.control
@@ -13,8 +13,8 @@ cfl                   = 0.4
 dcfl                  = 0.4
 mach number           = 0.5
 Reynolds number       = 100.0
-AOA theta             = 30.0
-AOA phi               = 30.0
+AOA theta             = 0.0
+AOA phi               = 0.0
 Riemann solver        = Roe
 
 #define boundary left__right__front__back__bottom__top


### PR DESCRIPTION
This PR adds a serial and parallel uniform-flow test for HOPR HDF5 meshes and incorporates the Epicure BSC optimizations for mesh read-in (all Epicure BSC optimizations have been added in #8). Some fixes were required to allow the mesh read-in optimizations to compile with support for HDF5 meshes.