### PR TITLE
Enable NSCylinderDucros build and run in CI workflow

### DIFF
--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -433,20 +433,19 @@ jobs:
 # 4) CYLINDER DUCROS
 # ------------------
 
-  # GPU
-      # - name: Build NSCylinderDucros
-      #   working-directory: ./Solver/test/NavierStokes/CylinderDucros/SETUP
-      #   run: |
-      #     source /opt/intel/oneapi/setvars.sh || true
-      #     make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-      #   if: '!cancelled()'
+      - name: Build NSCylinderDucros
+        working-directory: ./Solver/test/NavierStokes/CylinderDucros/SETUP
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
 
-      # - name: Run NSCylinderDucros
-      #   working-directory: ./Solver/test/NavierStokes/CylinderDucros
-      #   run: |
-      #     source /opt/intel/oneapi/setvars.sh || true
-      #     mpiexec -n 8 ./horses3d.ns CylinderDucros.control
-      #   if: '!cancelled()'
+      - name: Run NSCylinderDucros
+        working-directory: ./Solver/test/NavierStokes/CylinderDucros
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          mpiexec -n 8 ./horses3d.ns CylinderDucros.control
+        if: '!cancelled()'
 
 #
 # 5) CYLINDER Smagorinsky


### PR DESCRIPTION
Uncomments and updates the build and run steps for NSCylinderDucros in the CI_parallel_NS.yml workflow. Adds MKL and HDF5 options to the build command to support additional dependencies.