### PR TITLE
ci(cylinder): add regression tests for additional flux formulations

### DIFF
--- a/.github/workflows/CI_parallel_GPU.yml
+++ b/.github/workflows/CI_parallel_GPU.yml
@@ -645,6 +645,372 @@ jobs:
           fi
         if: '!cancelled()'
 
+#
+# 40) CYLINDER EntropyConservingCentral
+# -------------------------------------
+      - name: Build NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderEntropyConservingCentral
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderEntropyConservingCentral.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 41) CYLINDER StandardCentral
+# ----------------------------
+      - name: Build NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderStandardCentral
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderStandardCentral.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 42) CYLINDER KennedyGruberLaxFriedrichs
+# ---------------------------------------
+      - name: Build NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderKennedyGruberLaxFriedrichs
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderKennedyGruberLaxFriedrichs.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 43) CYLINDER MorinishiLowDissipationRoe
+# ----------------------------------------
+      - name: Build NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderMorinishiLowDissipationRoe
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderMorinishiLowDissipationRoe.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 44) CYLINDER DucrosMatrixDissipation
+# -------------------------------------
+      - name: Build NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderDucrosMatrixDissipation
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderDucrosMatrixDissipation.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 45) CYLINDER PirozzoliRoe
+# -------------------------
+      - name: Build NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          make clean || true
+          make ns COMPILER=nvfortran COMM=PARALLEL ENABLE_THREADS=NO WITH_METIS=YES
+        if: '!cancelled()'
+      - name: Run NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderPirozzoliRoe
+          #SBATCH --ntasks=2
+          #SBATCH --partition=gpu
+          #SBATCH --mem=32G
+          #SBATCH --gres=gpu:2
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          export NVCOMPILER_COMM_LIBS_HOME=$NVHPC_ROOT/comm_libs/12.6
+          export OPAL_PREFIX=$NVHPC_ROOT/comm_libs/mpi
+          mpirun -np 2 --bind-to none ./horses3d.ns CylinderPirozzoliRoe.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
 ########################################################################
 #######                INCOMPRESSIBLE_NS TESTS                 ########
 ########################################################################

--- a/.github/workflows/CI_parallel_NS.yml
+++ b/.github/workflows/CI_parallel_NS.yml
@@ -1149,3 +1149,110 @@ jobs:
           source /opt/intel/oneapi/setvars.sh || true
           mpiexec --oversubscribe -n 64 ./horses3d.ns Channel.control
         if: '!cancelled()'
+#
+# 40) CYLINDER EntropyConservingCentral
+# -------------------------------------
+
+      - name: Build NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderEntropyConservingCentral.control
+        if: '!cancelled()'
+
+#
+# 41) CYLINDER StandardCentral
+# ----------------------------
+
+      - name: Build NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderStandardCentral.control
+        if: '!cancelled()'
+
+#
+# 42) CYLINDER KennedyGruberLaxFriedrichs
+# ---------------------------------------
+
+      - name: Build NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderKennedyGruberLaxFriedrichs.control
+        if: '!cancelled()'
+
+#
+# 43) CYLINDER MorinishiLowDissipationRoe
+# ---------------------------------------
+
+      - name: Build NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderMorinishiLowDissipationRoe.control
+        if: '!cancelled()'
+
+#
+# 44) CYLINDER DucrosMatrixDissipation
+# ------------------------------------
+
+      - name: Build NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderDucrosMatrixDissipation.control
+        if: '!cancelled()'
+
+#
+# 45) CYLINDER PirozzoliRoe
+# -------------------------
+
+      - name: Build NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe/SETUP
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          make ns MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        if: '!cancelled()'
+
+      - name: Run NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe
+        run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          mpiexec --oversubscribe -n 8 ./horses3d.ns CylinderPirozzoliRoe.control
+        if: '!cancelled()'

--- a/.github/workflows/CI_serial_GPU.yml
+++ b/.github/workflows/CI_serial_GPU.yml
@@ -564,7 +564,336 @@ jobs:
             exit 1
           fi
         if: '!cancelled()'
-
+#
+# 40) CYLINDER EntropyConservingCentral
+# -------------------------------------
+      - name: Build NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderEntropyConservingCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderEntropyConservingCentral
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderEntropyConservingCentral
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderEntropyConservingCentral.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 41) CYLINDER StandardCentral
+# ----------------------------
+      - name: Build NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderStandardCentral
+        working-directory: ./Solver/test/NavierStokes/CylinderStandardCentral
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderStandardCentral
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderStandardCentral.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 42) CYLINDER KennedyGruberLaxFriedrichs
+# ---------------------------------------
+      - name: Build NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderKennedyGruberLaxFriedrichs
+        working-directory: ./Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderKennedyGruberLaxFriedrichs
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderKennedyGruberLaxFriedrichs.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 43) CYLINDER MorinishiLowDissipationRoe
+# ----------------------------------------
+      - name: Build NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderMorinishiLowDissipationRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderMorinishiLowDissipationRoe
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderMorinishiLowDissipationRoe.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 44) CYLINDER DucrosMatrixDissipation
+# -------------------------------------
+      - name: Build NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderDucrosMatrixDissipation
+        working-directory: ./Solver/test/NavierStokes/CylinderDucrosMatrixDissipation
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderDucrosMatrixDissipation
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderDucrosMatrixDissipation.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
+#
+# 45) CYLINDER PirozzoliRoe
+# -------------------------
+      - name: Build NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe/SETUP
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          make clean || true
+          make ns COMPILER=nvfortran COMM=SERIAL ENABLE_THREADS=NO
+        if: '!cancelled()'
+      - name: Run NSCylinderPirozzoliRoe
+        working-directory: ./Solver/test/NavierStokes/CylinderPirozzoliRoe
+        run: |
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          cat > run_test.sh << 'EOF'
+          #!/bin/bash
+          #SBATCH --job-name=NSCylinderPirozzoliRoe
+          #SBATCH --ntasks=1
+          #SBATCH --mem=20G
+          #SBATCH --partition=gpu
+          #SBATCH --gres=gpu:1
+          #SBATCH --time=00:15:00
+          module purge
+          module load hpc_sdk
+          module load nvhpc/24.11
+          export NVHPC_CUDA_HOME=$NVHPC_ROOT/cuda
+          export CUDA_HOME=$NVHPC_CUDA_HOME
+          export CUDA_PATH=$NVHPC_CUDA_HOME
+          export LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.6/targets/x86_64-linux/lib:$NVHPC_CUDA_HOME/lib64:$LIBRARY_PATH
+          ./horses3d.ns CylinderPirozzoliRoe.control
+          EOF
+          job_id=$(sbatch --parsable run_test.sh)
+          while squeue -j $job_id 2>/dev/null | grep -q $job_id; do sleep 10; done
+          cat slurm-${job_id}.out
+          exit_code=$(sacct -j $job_id --format=ExitCode --noheader | head -1 | tr -d ' ' | cut -d':' -f1)
+          if [ "$exit_code" != "0" ]; then
+            echo "Test failed with exit code: $exit_code"
+            exit 1
+          fi
+        if: '!cancelled()'
 ########################################################################
 #######                INCOMPRESSIBLE_NS TESTS                 ########
 ########################################################################

--- a/Solver/configure
+++ b/Solver/configure
@@ -56,12 +56,12 @@ TEST_CASES="./Euler/BoxAroundCircle \
             ./NavierStokes/CylinderWALE \
             ./NavierStokes/CylinderVreman \
             ./NavierStokes/CylinderChandrasekarRoe \
-            ./NavierStokes/CylinderEntropyConservingCentral
-            ./NavierStokes/CylinderStandardCentral
-            ./NavierStokes/CylinderKennedyGruberLaxFriedrichs
-            ./NavierStokes/CylinderMorinishiLowDissipationRoe
-            ./NavierStokes/CylinderDucrosMatrixDissipation
-            ./NavierStokes/CylinderPirozzoliRoe
+            ./NavierStokes/CylinderEntropyConservingCentral \
+            ./NavierStokes/CylinderStandardCentral \
+            ./NavierStokes/CylinderKennedyGruberLaxFriedrichs \
+            ./NavierStokes/CylinderMorinishiLowDissipationRoe \
+            ./NavierStokes/CylinderDucrosMatrixDissipation \
+            ./NavierStokes/CylinderPirozzoliRoe \
             ./NavierStokes/IBM_Cylinder \
             ./NavierStokes/DualTimeStepping \
             ./NavierStokes/EntropyConservingTest \

--- a/Solver/configure
+++ b/Solver/configure
@@ -56,6 +56,12 @@ TEST_CASES="./Euler/BoxAroundCircle \
             ./NavierStokes/CylinderWALE \
             ./NavierStokes/CylinderVreman \
             ./NavierStokes/CylinderChandrasekarRoe \
+            ./NavierStokes/CylinderEntropyConservingCentral
+            ./NavierStokes/CylinderStandardCentral
+            ./NavierStokes/CylinderKennedyGruberLaxFriedrichs
+            ./NavierStokes/CylinderMorinishiLowDissipationRoe
+            ./NavierStokes/CylinderDucrosMatrixDissipation
+            ./NavierStokes/CylinderPirozzoliRoe
             ./NavierStokes/IBM_Cylinder \
             ./NavierStokes/DualTimeStepping \
             ./NavierStokes/EntropyConservingTest \

--- a/Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/CylinderDucrosMatrixDissipation.control
+++ b/Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/CylinderDucrosMatrixDissipation.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Matrix Dissipation !Low dissipation roe !roe! Lax-Friedrichs !
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Ducros !Morinishi! Kennedy-Gruber
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderDucrosMatrixDissipation/SETUP/ProblemFile.f90
@@ -1,0 +1,621 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Ducros Matrix Dissipation"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+
+            real(kind=RP), parameter           :: cd =  35.379997072312094_RP
+            real(kind=RP), parameter           :: cl =  -2.1241135230720687E-4_RP
+            real(kind=RP), parameter           :: wake_u = 3.3320942537568965E-14_RP
+            real(kind=RP), parameter           :: res(5) = [  9.4135678581799436_RP, &
+                                                              24.424719509606117_RP, &
+                                                              0.23222549768718465_RP, &
+                                                              27.441862993921387_RP, &
+                                                              257.66848543195681_RP]
+
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/CylinderEntropyConservingCentral/CylinderEntropyConservingCentral.control
+++ b/Solver/test/NavierStokes/CylinderEntropyConservingCentral/CylinderEntropyConservingCentral.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Central
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Entropy conserving
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderEntropyConservingCentral/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderEntropyConservingCentral/SETUP/ProblemFile.f90
@@ -1,0 +1,620 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Entropy Conserving Central"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+            real(kind=RP), parameter           :: cd =  30.232044212322098_RP
+            real(kind=RP), parameter           :: cl =  -7.9060459381907755E-4_RP
+            real(kind=RP), parameter           :: wake_u = 5.8086204355573986E-13_RP
+            real(kind=RP), parameter           :: res(5) = [  22.587983152270393_RP, &
+                                                              51.290567421047967_RP, &
+                                                              0.90349487474767198_RP, &
+                                                              46.667396779232845_RP, &
+                                                              688.66297319768853_RP]
+
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/CylinderKennedyGruberLaxFriedrichs.control
+++ b/Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/CylinderKennedyGruberLaxFriedrichs.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Lax-Friedrichs !
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Kennedy-Gruber
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderKennedyGruberLaxFriedrichs/SETUP/ProblemFile.f90
@@ -1,0 +1,619 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Kennedy Gruber Lax-Friedrichs"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+            real(kind=RP), parameter           :: cd =  35.582694397987709_RP
+            real(kind=RP), parameter           :: cl =  -7.2266057384817728E-4_RP
+            real(kind=RP), parameter           :: wake_u = -5.7724553748447095E-15_RP
+            real(kind=RP), parameter           :: res(5) = [  9.2719987527753478_RP, &
+                                                              23.905773102558133_RP, &
+                                                              0.24941567206373649_RP, &
+                                                              26.933195557487711_RP, &
+                                                              253.84239859023091_RP]
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/CylinderMorinishiLowDissipationRoe.control
+++ b/Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/CylinderMorinishiLowDissipationRoe.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Low dissipation roe 
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Morinishi
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderMorinishiLowDissipationRoe/SETUP/ProblemFile.f90
@@ -1,0 +1,620 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Morinishi Low Dissipation Roe"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+            real(kind=RP), parameter           :: cd =  31.288682485126813_RP
+            real(kind=RP), parameter           :: cl =  5.3804847888860863E-5_RP
+            real(kind=RP), parameter           :: wake_u = -5.9278253501887072E-14_RP
+            real(kind=RP), parameter           :: res(5) = [  12.013278941902202_RP, &
+                                                              23.167624131000281_RP, &
+                                                              0.41693163202298855_RP, &
+                                                              29.046724750444895_RP, &
+                                                              361.33241532835217_RP]
+
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/CylinderPirozzoliRoe/CylinderPirozzoliRoe.control
+++ b/Solver/test/NavierStokes/CylinderPirozzoliRoe/CylinderPirozzoliRoe.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Roe !Matrix Dissipation !Low dissipation roe !roe! Lax-Friedrichs !
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Pirozzoli !Ducros !Morinishi! Kennedy-Gruber
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderPirozzoliRoe/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderPirozzoliRoe/SETUP/ProblemFile.f90
@@ -1,0 +1,621 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Pirozzoli Roe"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+
+            real(kind=RP), parameter           :: cd =  35.380054657588104_RP
+            real(kind=RP), parameter           :: cl =  -2.1675480592953100E-4_RP
+            real(kind=RP), parameter           :: wake_u = 3.0675148576095859E-14_RP
+            real(kind=RP), parameter           :: res(5) = [  9.3478957716597240_RP, &
+                                                              23.979434461004804_RP, &
+                                                              0.22647324206784938_RP, &
+                                                              27.486657517616088_RP, &
+                                                              255.31420936461873_RP]
+
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      

--- a/Solver/test/NavierStokes/CylinderStandardCentral/CylinderStandardCentral.control
+++ b/Solver/test/NavierStokes/CylinderStandardCentral/CylinderStandardCentral.control
@@ -1,0 +1,69 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 100
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+cfl                   = 0.3
+dcfl                  = 0.3
+mach number           = 0.3
+Reynolds number       = 200.0
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver          = Central 
+Discretization nodes    = Gauss-Lobatto
+inviscid discretization = Split-Form
+averaging               = Standard
+Viscous discretization  = BR1
+
+#define boundary InnerCylinder
+      type = NoSlipWall
+#end
+
+#define boundary Front__Back__Left
+      type = Inflow
+#end
+
+#define boundary Bottom__Top
+      type = FreeSlipWall
+#end
+
+#define boundary Right
+      type = Outflow
+#end
+
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/CylinderStandardCentral/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/CylinderStandardCentral/SETUP/ProblemFile.f90
@@ -1,0 +1,620 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Cylinder Standard Central"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+            integer                            :: rank, io
+            real(kind=RP), parameter           :: cd =  28.805599476649469_RP
+            real(kind=RP), parameter           :: cl =  -1.5883118237667304E-3_RP
+            real(kind=RP), parameter           :: wake_u = 1.2659185030528810E-12_RP
+            real(kind=RP), parameter           :: res(5) = [  19.084233164528808_RP, &
+                                                              46.217035929298568_RP, &
+                                                              0.84940638223556375_RP, &
+                                                              56.536819235670350_RP, &
+                                                              568.29482399737981_RP]
+
+#if defined(NAVIERSTOKES)
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+            
+            CALL FTAssertEqual(expectedValue = res(1) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "continuity residual")
+
+            CALL FTAssertEqual(expectedValue = res(2) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "x-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(3) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "y-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(4) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "z-momentum residual")
+
+            CALL FTAssertEqual(expectedValue = res(5) + 1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1) + 1.0_RP, &
+                               tol           = 1.0e-7_RP, &
+                               msg           = "energy residual")
+
+            CALL FTAssertEqual(expectedValue = wake_u + 1.0_RP, &
+                               actualValue   = monitors % probes(1) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Wake final x-velocity at the point [0,2.0,4.0]")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+           CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      


### PR DESCRIPTION
Add Navier–Stokes cylinder CI cases for:
- EntropyConservingCentral
- StandardCentral
- KennedyGruberLaxFriedrichs
- MorinishiLowDissipationRoe
- DucrosMatrixDissipation
- PirozzoliRoe

Includes:
- new test folders and control files
- CI build/run entries
- NVHPC GPU Slurm regression jobs
- reference residuals and force coefficients