### PR TITLE
Add wall shear stress vector (u_tau_vector) support for horses2plt surface postprocessing

### DIFF
--- a/Solver/src/addons/horses2tecplot/OutputVariables.f90
+++ b/Solver/src/addons/horses2tecplot/OutputVariables.f90
@@ -51,6 +51,7 @@ module OutputVariables
       enumerator :: ReSTxx, ReSTxy, ReSTxz, ReSTyy, ReSTyz, ReSTzz
       enumerator :: Vfvec_Vrms, Uf_Vrms, Vf_Vrms, Wf_Vrms
       enumerator :: U_TAU_V, WallY_V, Tauw_V, MU, YPLUS, Cf_V, MUTMINF
+      enumerator :: WTauVec_V, WTAUX_V, WTAUY_V, WTAUZ_V
       enumerator :: MU_sgs_V, SENSOR_V
       enumerator :: LASTVARIABLE
    end enum
@@ -134,6 +135,10 @@ module OutputVariables
    character(len=STR_VAR_LEN), parameter  :: UTAUKey       = "u_tau"
    character(len=STR_VAR_LEN), parameter  :: WallYKey      = "wall_distance"
    character(len=STR_VAR_LEN), parameter  :: TauwKey       = "wall_shear"
+   character(len=STR_VAR_LEN), parameter  :: WTauVecKey    = "w_tau"
+   character(len=STR_VAR_LEN), parameter  :: WTauXKey      = "w_tau_x"
+   character(len=STR_VAR_LEN), parameter  :: WTauYKey      = "w_tau_y"
+   character(len=STR_VAR_LEN), parameter  :: WTauZKey      = "w_tau_z"
    character(len=STR_VAR_LEN), parameter  :: muKey         = "mu_ns"
    character(len=STR_VAR_LEN), parameter  :: yplusKey      = "yplus"
    character(len=STR_VAR_LEN), parameter  :: cfKey         = "Cf"
@@ -157,7 +162,9 @@ module OutputVariables
                                                                             ReSTxxKey, ReSTxyKey, ReSTxzKey, ReSTyyKey, ReSTyzKey, ReSTzzKey, &
                                                                             VfvecRmsKey, UfRmsKey, VfRmsKey, WfRmsKey, &
                                                                             UTAUKey, WallYKey, TauwKey, muKey, yplusKey, &
-                                                                            cfKey, mutminfKey, muSGSKey, sensorKey /)
+                                                                            cfKey, mutminfKey, &
+                                                                            WTauVecKey, WTauXKey, WTauYKey, WTauZKey, &
+                                                                            muSGSKey, sensorKey /)
                                                                         
                                                                         
                                                                
@@ -295,7 +302,7 @@ module OutputVariables
          real(kind=RP) :: Sym, Asym
          logical       :: hasAdditionalVariables
 
-         hasAdditionalVariables = hasUt_NS .or. hasWallY .or. hasMu_NS .or. hasStats .or. hasGradients .or. hasSensor .or. hasMu_sgs
+         hasAdditionalVariables = hasUt_NS .or. hasWtau_NS .or. hasWallY .or. hasMu_NS .or. hasStats .or. hasGradients .or. hasSensor .or. hasMu_sgs
 
          do var = 1, noOutput
             if ( hasAdditionalVariables .or. (outputVarNames(var) .le. NO_OF_INVISCID_VARIABLES ) ) then
@@ -307,6 +314,7 @@ module OutputVariables
                            mu_NS => e % mu_NSout, &
                            wallY => e % wallY, &
                            u_tau=> e % ut_NS, &
+                           w_tau=> e % wtau_NS, &
                            mu_sgs => e % mu_sgsout, &
                            stats => e % statsout)
 
@@ -705,6 +713,24 @@ module OutputVariables
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * Lreference
 
+               case(WTAUX_V)
+                  do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
+                     output(var,i,j,k) =  w_tau(1,i,j,k)
+                  end do         ; end do         ; end do
+                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+
+               case(WTAUY_V)
+                  do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
+                     output(var,i,j,k) =  w_tau(2,i,j,k)
+                  end do         ; end do         ; end do
+                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+
+               case(WTAUZ_V)
+                  do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
+                     output(var,i,j,k) =  w_tau(3,i,j,k)
+                  end do         ; end do         ; end do
+                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+
                case(MU_sgs_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) = mu_sgs(1,i,j,k) !* refs(RE_REF)
@@ -855,6 +881,9 @@ module OutputVariables
          case(Vfvec_Vrms)
             outputVariablesForVariable = 3
 
+         case(WTauVec_V)
+            outputVariablesForVariable = 3
+
          case default
             outputVariablesForVariable = 1
 
@@ -917,6 +946,9 @@ module OutputVariables
 
          case(Vfvec_Vrms)
             output = (/Uf_Vrms, Vf_Vrms, Wf_Vrms/)
+
+         case(WTauVec_V)
+            output = (/WTAUX_V, WTAUY_V, WTAUZ_V/)
 
          case default
             output = iVar

--- a/Solver/src/addons/horses2tecplot/OutputVariables.f90
+++ b/Solver/src/addons/horses2tecplot/OutputVariables.f90
@@ -51,7 +51,7 @@ module OutputVariables
       enumerator :: ReSTxx, ReSTxy, ReSTxz, ReSTyy, ReSTyz, ReSTzz
       enumerator :: Vfvec_Vrms, Uf_Vrms, Vf_Vrms, Wf_Vrms
       enumerator :: U_TAU_V, WallY_V, Tauw_V, MU, YPLUS, Cf_V, MUTMINF
-      enumerator :: WTauVec_V, WTAUX_V, WTAUY_V, WTAUZ_V
+      enumerator :: UTauVec_V, UTAUX_V, UTAUY_V, UTAUZ_V
       enumerator :: MU_sgs_V, SENSOR_V
       enumerator :: LASTVARIABLE
    end enum
@@ -135,10 +135,10 @@ module OutputVariables
    character(len=STR_VAR_LEN), parameter  :: UTAUKey       = "u_tau"
    character(len=STR_VAR_LEN), parameter  :: WallYKey      = "wall_distance"
    character(len=STR_VAR_LEN), parameter  :: TauwKey       = "wall_shear"
-   character(len=STR_VAR_LEN), parameter  :: WTauVecKey    = "w_tau"
-   character(len=STR_VAR_LEN), parameter  :: WTauXKey      = "w_tau_x"
-   character(len=STR_VAR_LEN), parameter  :: WTauYKey      = "w_tau_y"
-   character(len=STR_VAR_LEN), parameter  :: WTauZKey      = "w_tau_z"
+   character(len=STR_VAR_LEN), parameter  :: UTauVecKey    = "u_tau_vector"
+   character(len=STR_VAR_LEN), parameter  :: UTauXKey      = "u_tau_x"
+   character(len=STR_VAR_LEN), parameter  :: UTauYKey      = "u_tau_y"
+   character(len=STR_VAR_LEN), parameter  :: UTauZKey      = "u_tau_z"
    character(len=STR_VAR_LEN), parameter  :: muKey         = "mu_ns"
    character(len=STR_VAR_LEN), parameter  :: yplusKey      = "yplus"
    character(len=STR_VAR_LEN), parameter  :: cfKey         = "Cf"
@@ -163,7 +163,7 @@ module OutputVariables
                                                                             VfvecRmsKey, UfRmsKey, VfRmsKey, WfRmsKey, &
                                                                             UTAUKey, WallYKey, TauwKey, muKey, yplusKey, &
                                                                             cfKey, mutminfKey, &
-                                                                            WTauVecKey, WTauXKey, WTauYKey, WTauZKey, &
+                                                                            UTauVecKey, UTauXKey, UTauYKey, UTauZKey, &
                                                                             muSGSKey, sensorKey /)
                                                                         
                                                                         
@@ -713,19 +713,19 @@ module OutputVariables
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * Lreference
 
-               case(WTAUX_V)
+               case(UTAUX_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(1,i,j,k)
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
 
-               case(WTAUY_V)
+               case(UTAUY_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(2,i,j,k)
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
 
-               case(WTAUZ_V)
+               case(UTAUZ_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(3,i,j,k)
                   end do         ; end do         ; end do
@@ -881,7 +881,7 @@ module OutputVariables
          case(Vfvec_Vrms)
             outputVariablesForVariable = 3
 
-         case(WTauVec_V)
+         case(UTauVec_V)
             outputVariablesForVariable = 3
 
          case default
@@ -947,8 +947,8 @@ module OutputVariables
          case(Vfvec_Vrms)
             output = (/Uf_Vrms, Vf_Vrms, Wf_Vrms/)
 
-         case(WTauVec_V)
-            output = (/WTAUX_V, WTAUY_V, WTAUZ_V/)
+         case(UTauVec_V)
+            output = (/UTAUX_V, UTAUY_V, UTAUZ_V/)
 
          case default
             output = iVar

--- a/Solver/src/addons/horses2tecplot/OutputVariables.f90
+++ b/Solver/src/addons/horses2tecplot/OutputVariables.f90
@@ -716,19 +716,19 @@ module OutputVariables
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(1,i,j,k)
                   end do         ; end do         ; end do
-                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+                  if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
                case(UTAUY_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(2,i,j,k)
                   end do         ; end do         ; end do
-                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+                  if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
                case(UTAUZ_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
                      output(var,i,j,k) =  w_tau(3,i,j,k)
                   end do         ; end do         ; end do
-                  if ( outScale ) output(var,:,:,:) = refs(RHO_REF) * POW2(refs(V_REF)) * output(var,:,:,:)
+                  if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
                case(MU_sgs_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)

--- a/Solver/src/addons/horses2tecplot/OutputVariables.f90
+++ b/Solver/src/addons/horses2tecplot/OutputVariables.f90
@@ -18,7 +18,7 @@ module OutputVariables
    use SMConstants
    use PhysicsStorage
    use Headers
-   use Storage, only: NVARS, hasMPIranks, hasUt_NS, hasWtau_NS
+   use Storage, only: NVARS, hasMPIranks, hasUt_NS, hasUTauVec_NS
 
    private
    public   no_of_outputVariables, preliminarNoOfVariables, askedVariables, getNoOfCommas
@@ -301,7 +301,7 @@ module OutputVariables
          real(kind=RP) :: Sym, Asym
          logical       :: hasAdditionalVariables
 
-         hasAdditionalVariables = hasUt_NS .or. hasWtau_NS .or. hasWallY .or. hasMu_NS .or. hasStats .or. hasGradients .or. hasSensor .or. hasMu_sgs
+         hasAdditionalVariables = hasUt_NS .or. hasUTauVec_NS .or. hasWallY .or. hasMu_NS .or. hasStats .or. hasGradients .or. hasSensor .or. hasMu_sgs
 
          do var = 1, noOutput
             if ( hasAdditionalVariables .or. (outputVarNames(var) .le. NO_OF_INVISCID_VARIABLES ) ) then
@@ -313,7 +313,7 @@ module OutputVariables
                            mu_NS => e % mu_NSout, &
                            wallY => e % wallY, &
                            u_tau=> e % ut_NS, &
-                           w_tau=> e % wtau_NS, &
+                           u_tau_vec=> e % u_tau_vec_NS, &
                            mu_sgs => e % mu_sgsout, &
                            stats => e % statsout)
 
@@ -714,19 +714,19 @@ module OutputVariables
 
                case(UTAUX_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
-                     output(var,i,j,k) =  w_tau(1,i,j,k)
+                     output(var,i,j,k) =  u_tau_vec(1,i,j,k)
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
                case(UTAUY_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
-                     output(var,i,j,k) =  w_tau(2,i,j,k)
+                     output(var,i,j,k) =  u_tau_vec(2,i,j,k)
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
                case(UTAUZ_V)
                   do k = 0, N(3) ; do j = 0, N(2) ; do i = 0, N(1)
-                     output(var,i,j,k) =  w_tau(3,i,j,k)
+                     output(var,i,j,k) =  u_tau_vec(3,i,j,k)
                   end do         ; end do         ; end do
                   if ( outScale ) output(var,:,:,:) = output(var,:,:,:) * refs(V_REF)
 
@@ -881,9 +881,9 @@ module OutputVariables
             outputVariablesForVariable = 3
 
          case(U_TAU_V)
-            if ( hasUt_NS .and. hasWtau_NS ) then
+            if ( hasUt_NS .and. hasUTauVec_NS ) then
                outputVariablesForVariable = 4
-            else if ( hasWtau_NS ) then
+            else if ( hasUTauVec_NS ) then
                outputVariablesForVariable = 3
             else
                outputVariablesForVariable = 1
@@ -953,9 +953,9 @@ module OutputVariables
             output = (/Uf_Vrms, Vf_Vrms, Wf_Vrms/)
 
          case(U_TAU_V)
-            if ( hasUt_NS .and. hasWtau_NS ) then
+            if ( hasUt_NS .and. hasUTauVec_NS ) then
                output = (/U_TAU_V, UTAUX_V, UTAUY_V, UTAUZ_V/)
-            else if ( hasWtau_NS ) then
+            else if ( hasUTauVec_NS ) then
                output = (/UTAUX_V, UTAUY_V, UTAUZ_V/)
             else
                output = (/U_TAU_V/)

--- a/Solver/src/addons/horses2tecplot/OutputVariables.f90
+++ b/Solver/src/addons/horses2tecplot/OutputVariables.f90
@@ -18,7 +18,7 @@ module OutputVariables
    use SMConstants
    use PhysicsStorage
    use Headers
-   use Storage, only: NVARS, hasMPIranks
+   use Storage, only: NVARS, hasMPIranks, hasUt_NS, hasWtau_NS
 
    private
    public   no_of_outputVariables, preliminarNoOfVariables, askedVariables, getNoOfCommas
@@ -51,7 +51,7 @@ module OutputVariables
       enumerator :: ReSTxx, ReSTxy, ReSTxz, ReSTyy, ReSTyz, ReSTzz
       enumerator :: Vfvec_Vrms, Uf_Vrms, Vf_Vrms, Wf_Vrms
       enumerator :: U_TAU_V, WallY_V, Tauw_V, MU, YPLUS, Cf_V, MUTMINF
-      enumerator :: UTauVec_V, UTAUX_V, UTAUY_V, UTAUZ_V
+      enumerator :: UTAUX_V, UTAUY_V, UTAUZ_V
       enumerator :: MU_sgs_V, SENSOR_V
       enumerator :: LASTVARIABLE
    end enum
@@ -135,7 +135,6 @@ module OutputVariables
    character(len=STR_VAR_LEN), parameter  :: UTAUKey       = "u_tau"
    character(len=STR_VAR_LEN), parameter  :: WallYKey      = "wall_distance"
    character(len=STR_VAR_LEN), parameter  :: TauwKey       = "wall_shear"
-   character(len=STR_VAR_LEN), parameter  :: UTauVecKey    = "u_tau_vector"
    character(len=STR_VAR_LEN), parameter  :: UTauXKey      = "u_tau_x"
    character(len=STR_VAR_LEN), parameter  :: UTauYKey      = "u_tau_y"
    character(len=STR_VAR_LEN), parameter  :: UTauZKey      = "u_tau_z"
@@ -163,7 +162,7 @@ module OutputVariables
                                                                             VfvecRmsKey, UfRmsKey, VfRmsKey, WfRmsKey, &
                                                                             UTAUKey, WallYKey, TauwKey, muKey, yplusKey, &
                                                                             cfKey, mutminfKey, &
-                                                                            UTauVecKey, UTauXKey, UTauYKey, UTauZKey, &
+                                                                            UTauXKey, UTauYKey, UTauZKey, &
                                                                             muSGSKey, sensorKey /)
                                                                         
                                                                         
@@ -881,8 +880,14 @@ module OutputVariables
          case(Vfvec_Vrms)
             outputVariablesForVariable = 3
 
-         case(UTauVec_V)
-            outputVariablesForVariable = 3
+         case(U_TAU_V)
+            if ( hasUt_NS .and. hasWtau_NS ) then
+               outputVariablesForVariable = 4
+            else if ( hasWtau_NS ) then
+               outputVariablesForVariable = 3
+            else
+               outputVariablesForVariable = 1
+            end if
 
          case default
             outputVariablesForVariable = 1
@@ -947,8 +952,14 @@ module OutputVariables
          case(Vfvec_Vrms)
             output = (/Uf_Vrms, Vf_Vrms, Wf_Vrms/)
 
-         case(UTauVec_V)
-            output = (/UTAUX_V, UTAUY_V, UTAUZ_V/)
+         case(U_TAU_V)
+            if ( hasUt_NS .and. hasWtau_NS ) then
+               output = (/U_TAU_V, UTAUX_V, UTAUY_V, UTAUZ_V/)
+            else if ( hasWtau_NS ) then
+               output = (/UTAUX_V, UTAUY_V, UTAUZ_V/)
+            else
+               output = (/U_TAU_V/)
+            end if
 
          case default
             output = iVar

--- a/Solver/src/addons/horses2tecplot/Storage.f90
+++ b/Solver/src/addons/horses2tecplot/Storage.f90
@@ -10,13 +10,13 @@ module Storage
    public Mesh_t, Element_t, Boundary_t
    public NVARS, NGRADVARS, hasMPIranks, hasBoundaries, isOldStats
    public partitionFileName, boundaryFileName, flowEq
-   public hasExtraGradients, hasMu_NS, hasUt_NS, hasWtau_NS, hasWallY, NSTAT, hasMu_sgs
+   public hasExtraGradients, hasMu_NS, hasUt_NS, hasUTauVec_NS, hasWallY, NSTAT, hasMu_sgs
 
    integer                          :: NVARS, NGRADVARS
    logical                          :: hasMPIranks, hasBoundaries, isOldStats
    logical                          :: hasExtraGradients = .false.
    logical                          :: hasUt_NS = .false.
-   logical                          :: hasWtau_NS = .false.
+   logical                          :: hasUTauVec_NS = .false.
    logical                          :: hasMu_NS = .false.
    logical                          :: hasWallY     = .false.
    logical                          :: hasMu_sgs = .false.
@@ -41,7 +41,7 @@ module Storage
       real(kind=RP), pointer     :: Q_z(:,:,:,:)
       real(kind=RP), pointer     :: mu_NS(:,:,:,:)
       real(kind=RP), pointer     :: ut_NS(:,:,:,:)
-      real(kind=RP), pointer     :: wtau_NS(:,:,:,:)
+      real(kind=RP), pointer     :: u_tau_vec_NS(:,:,:,:)
       real(kind=RP), pointer     :: wallY(:,:,:,:)
       real(kind=RP), pointer     :: mu_sgs(:,:,:,:)
       real(kind=RP), pointer     :: stats(:,:,:,:)
@@ -403,9 +403,9 @@ module Storage
                    read(fid) e % ut_NS
                end if
 
-               if (hasWtau_NS) then
-                   allocate( e % wtau_NS(NDIM,0:e % Nsol(1),0:e % Nsol(2),0:e % Nsol(3)) )
-                   read(fid) e % wtau_NS
+               if (hasUTauVec_NS) then
+                   allocate( e % u_tau_vec_NS(NDIM,0:e % Nsol(1),0:e % Nsol(2),0:e % Nsol(3)) )
+                   read(fid) e % u_tau_vec_NS
                end if
 
                if (hasMu_NS) then

--- a/Solver/src/addons/horses2tecplot/Storage.f90
+++ b/Solver/src/addons/horses2tecplot/Storage.f90
@@ -10,12 +10,13 @@ module Storage
    public Mesh_t, Element_t, Boundary_t
    public NVARS, NGRADVARS, hasMPIranks, hasBoundaries, isOldStats
    public partitionFileName, boundaryFileName, flowEq
-   public hasExtraGradients, hasMu_NS, hasUt_NS, hasWallY, NSTAT, hasMu_sgs
+   public hasExtraGradients, hasMu_NS, hasUt_NS, hasWtau_NS, hasWallY, NSTAT, hasMu_sgs
 
    integer                          :: NVARS, NGRADVARS
    logical                          :: hasMPIranks, hasBoundaries, isOldStats
    logical                          :: hasExtraGradients = .false.
    logical                          :: hasUt_NS = .false.
+   logical                          :: hasWtau_NS = .false.
    logical                          :: hasMu_NS = .false.
    logical                          :: hasWallY     = .false.
    logical                          :: hasMu_sgs = .false.
@@ -40,6 +41,7 @@ module Storage
       real(kind=RP), pointer     :: Q_z(:,:,:,:)
       real(kind=RP), pointer     :: mu_NS(:,:,:,:)
       real(kind=RP), pointer     :: ut_NS(:,:,:,:)
+      real(kind=RP), pointer     :: wtau_NS(:,:,:,:)
       real(kind=RP), pointer     :: wallY(:,:,:,:)
       real(kind=RP), pointer     :: mu_sgs(:,:,:,:)
       real(kind=RP), pointer     :: stats(:,:,:,:)
@@ -399,7 +401,12 @@ module Storage
                if (hasUt_NS) then
                    allocate( e % ut_NS(1,0:e % Nsol(1),0:e % Nsol(2),0:e % Nsol(3)) )
                    read(fid) e % ut_NS
-               end if 
+               end if
+
+               if (hasWtau_NS) then
+                   allocate( e % wtau_NS(NDIM,0:e % Nsol(1),0:e % Nsol(2),0:e % Nsol(3)) )
+                   read(fid) e % wtau_NS
+               end if
 
                if (hasMu_NS) then
                    allocate( e % mu_NS(1,0:e % Nsol(1),0:e % Nsol(2),0:e % Nsol(3)) )

--- a/Solver/src/addons/horses2tecplot/getTask.f90
+++ b/Solver/src/addons/horses2tecplot/getTask.f90
@@ -346,7 +346,7 @@ module getTask
                     case ("u_tau")
                         hasUt_NS = .true.
                     case ("u_tau_vector")
-                        hasWtau_NS = .true.
+                        hasUTauVec_NS = .true.
                     case ("turb")
                         hasMu_NS = .true.
                         hasWallY     = .true.

--- a/Solver/src/addons/horses2tecplot/getTask.f90
+++ b/Solver/src/addons/horses2tecplot/getTask.f90
@@ -345,7 +345,7 @@ module getTask
                 select case (trim(addVar))
                     case ("u_tau")
                         hasUt_NS = .true.
-                    case ("w_tau")
+                    case ("u_tau_vector")
                         hasWtau_NS = .true.
                     case ("turb")
                         hasMu_NS = .true.

--- a/Solver/src/addons/horses2tecplot/getTask.f90
+++ b/Solver/src/addons/horses2tecplot/getTask.f90
@@ -345,6 +345,8 @@ module getTask
                 select case (trim(addVar))
                     case ("u_tau")
                         hasUt_NS = .true.
+                    case ("w_tau")
+                        hasWtau_NS = .true.
                     case ("turb")
                         hasMu_NS = .true.
                         hasWallY     = .true.

--- a/Solver/src/libs/mesh/StorageClass.f90
+++ b/Solver/src/libs/mesh/StorageClass.f90
@@ -200,6 +200,7 @@ module StorageClass
       real(kind=RP), dimension(:,:),       allocatable :: rho
       real(kind=RP), dimension(:,:,:),     allocatable :: mu_NS
       real(kind=RP), dimension(:,:),       allocatable :: u_tau_NS
+      real(kind=RP), dimension(:,:,:),     allocatable :: w_tau_NS ! tangential wall shear stress vector (1:NDIM,:,:)
       real(kind=RP), dimension(:,:),       allocatable :: wallNodeDistance ! for BC walls, distance to the first fluid node
 #ifdef ACOUSTIC
       real(kind=RP), dimension(:,:,:),     allocatable :: Qbase ! Base flow State vector
@@ -1417,6 +1418,7 @@ module StorageClass
 #ifndef ACOUSTIC
          allocate( self % mu_NS     (1:3,0:Nf(1),0:Nf(2)) )
          allocate( self % u_tau_NS  (0:Nf(1),0:Nf(2)) )
+         allocate( self % w_tau_NS  (1:NDIM,0:Nf(1),0:Nf(2)) )
          allocate( self % wallNodeDistance  (0:Nf(1),0:Nf(2)) )
 #endif
          
@@ -1478,6 +1480,7 @@ module StorageClass
 #ifndef ACOUSTIC
          self % mu_NS  = 0.0_RP
          self % u_tau_NS = 1.0_RP
+         self % w_tau_NS = 0.0_RP
          self % wallNodeDistance = 0.0_RP
 #endif
 
@@ -1573,6 +1576,7 @@ module StorageClass
          end if
          safedeallocate(self % mu_NS)
          safedeallocate(self % u_tau_NS)
+         safedeallocate(self % w_tau_NS)
          safedeallocate(self % wallNodeDistance)
          safedeallocate(self % rho )
 #if defined (ACOUSTIC)
@@ -1745,6 +1749,7 @@ module StorageClass
 #ifndef ACOUSTIC
          to % mu_NS  = from % mu_NS
          to % u_tau_NS  = from % u_tau_NS
+         to % w_tau_NS  = from % w_tau_NS
          to % wallNodeDistance  = from % wallNodeDistance
 #endif
 

--- a/Solver/src/libs/mesh/StorageClass.f90
+++ b/Solver/src/libs/mesh/StorageClass.f90
@@ -200,7 +200,7 @@ module StorageClass
       real(kind=RP), dimension(:,:),       allocatable :: rho
       real(kind=RP), dimension(:,:,:),     allocatable :: mu_NS
       real(kind=RP), dimension(:,:),       allocatable :: u_tau_NS
-      real(kind=RP), dimension(:,:,:),     allocatable :: w_tau_NS ! friction velocity vector, velocity units (1:NDIM,:,:)
+      real(kind=RP), dimension(:,:,:),     allocatable :: u_tau_vec_NS ! friction velocity vector, velocity units (1:NDIM,:,:)
       real(kind=RP), dimension(:,:),       allocatable :: wallNodeDistance ! for BC walls, distance to the first fluid node
 #ifdef ACOUSTIC
       real(kind=RP), dimension(:,:,:),     allocatable :: Qbase ! Base flow State vector
@@ -1418,7 +1418,7 @@ module StorageClass
 #ifndef ACOUSTIC
          allocate( self % mu_NS     (1:3,0:Nf(1),0:Nf(2)) )
          allocate( self % u_tau_NS  (0:Nf(1),0:Nf(2)) )
-         allocate( self % w_tau_NS  (1:NDIM,0:Nf(1),0:Nf(2)) )
+         allocate( self % u_tau_vec_NS  (1:NDIM,0:Nf(1),0:Nf(2)) )
          allocate( self % wallNodeDistance  (0:Nf(1),0:Nf(2)) )
 #endif
          
@@ -1480,7 +1480,7 @@ module StorageClass
 #ifndef ACOUSTIC
          self % mu_NS  = 0.0_RP
          self % u_tau_NS = 1.0_RP
-         self % w_tau_NS = 0.0_RP
+         self % u_tau_vec_NS = 0.0_RP
          self % wallNodeDistance = 0.0_RP
 #endif
 
@@ -1576,7 +1576,7 @@ module StorageClass
          end if
          safedeallocate(self % mu_NS)
          safedeallocate(self % u_tau_NS)
-         safedeallocate(self % w_tau_NS)
+         safedeallocate(self % u_tau_vec_NS)
          safedeallocate(self % wallNodeDistance)
          safedeallocate(self % rho )
 #if defined (ACOUSTIC)
@@ -1749,7 +1749,7 @@ module StorageClass
 #ifndef ACOUSTIC
          to % mu_NS  = from % mu_NS
          to % u_tau_NS  = from % u_tau_NS
-         to % w_tau_NS  = from % w_tau_NS
+         to % u_tau_vec_NS  = from % u_tau_vec_NS
          to % wallNodeDistance  = from % wallNodeDistance
 #endif
 

--- a/Solver/src/libs/mesh/StorageClass.f90
+++ b/Solver/src/libs/mesh/StorageClass.f90
@@ -200,7 +200,7 @@ module StorageClass
       real(kind=RP), dimension(:,:),       allocatable :: rho
       real(kind=RP), dimension(:,:,:),     allocatable :: mu_NS
       real(kind=RP), dimension(:,:),       allocatable :: u_tau_NS
-      real(kind=RP), dimension(:,:,:),     allocatable :: w_tau_NS ! tangential wall shear stress vector (1:NDIM,:,:)
+      real(kind=RP), dimension(:,:,:),     allocatable :: w_tau_NS ! friction velocity vector, velocity units (1:NDIM,:,:)
       real(kind=RP), dimension(:,:),       allocatable :: wallNodeDistance ! for BC walls, distance to the first fluid node
 #ifdef ACOUSTIC
       real(kind=RP), dimension(:,:,:),     allocatable :: Qbase ! Base flow State vector

--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -131,7 +131,7 @@ Module SurfaceMesh
         sliceTolerance = controlVariables % getValueOrDefault("slice tolerance", 1.0e-4_RP)
         self % saveGradients = controlVariables % logicalValueForKey("surface save gradients") .or. controlVariables % logicalValueForKey("save gradients")
         self % saveUt = controlVariables % logicalValueForKey("surface save utau")
-        self % saveWtau = controlVariables % logicalValueForKey("surface save w_tau")
+        self % saveWtau = controlVariables % logicalValueForKey("surface save utau vector")
         self % saveTurb = controlVariables % logicalValueForKey("surface save turbulent")
 !
 !       get number of surfaces

--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -747,10 +747,12 @@ Module SurfaceMesh
           end if
       end select
 
+#if defined(NAVIERSTOKES)
       if (saveUt) padding = padding + 1
       if (saveWtau) padding = padding + NDIM
       ! save mu_NS and y, for y+ value calc
       if (saveTurb) padding = padding + 2
+#endif
 !
 !     Create new file
 !     ---------------

--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -43,7 +43,7 @@ Module SurfaceMesh
         logical                                                 :: mergeFWHandBC    ! flag to merge 2 surfaces if they have the same BCs
         logical                                                 :: active           ! flag use for save at least one file
         logical                                                 :: saveUt           ! flag use for save friction velocity in bcs
-        logical                                                 :: saveWtau         ! flag use for save wall shear stress vector in bcs
+        logical                                                 :: saveUtauVector   ! flag use for save friction-velocity vector in bcs
         logical                                                 :: saveTurb         ! flag use for save wall normal distance, and viscosity
 
         contains
@@ -131,7 +131,7 @@ Module SurfaceMesh
         sliceTolerance = controlVariables % getValueOrDefault("slice tolerance", 1.0e-4_RP)
         self % saveGradients = controlVariables % logicalValueForKey("surface save gradients") .or. controlVariables % logicalValueForKey("save gradients")
         self % saveUt = controlVariables % logicalValueForKey("surface save utau")
-        self % saveWtau = controlVariables % logicalValueForKey("surface save utau vector")
+        self % saveUtauVector = controlVariables % logicalValueForKey("surface save utau vector")
         self % saveTurb = controlVariables % logicalValueForKey("surface save turbulent")
 !
 !       get number of surfaces
@@ -468,13 +468,13 @@ Module SurfaceMesh
         character(len=LINE_LENGTH)                          :: FinalName      !  Final name for particular file
         logical                                             :: saveFWH
         integer, dimension(:), allocatable                  :: elemSide
-        logical                                             :: saveUt, saveWtau, saveTurb
+        logical                                             :: saveUt, saveUtauVector, saveTurb
 
         if (.not. self % active) return
         saveFWH = controlVariables % logicalValueForKey("acoustic solution save") .or. self % mergeFWHandBC
         do i = 1, self % numberOfSurfaces
             saveUt = .false.
-            saveWtau = .false.
+            saveUtauVector = .false.
             saveTurb = .false.
             if (.not. self % surfaceActive(i)) cycle
             !skip fwh if not requested
@@ -494,14 +494,14 @@ Module SurfaceMesh
                  (self % surfaceTypes(i) .eq. SURFACE_TYPE_FWH .and. self % mergeFWHandBC) ) then
                 if (self%isNoSlip(i)) then
                     saveUt = self % saveUt
-                    saveWtau = self % saveWtau
+                    saveUtauVector = self % saveUtauVector
                     saveTurb = self % saveTurb
                 end if
             end if
             call SurfaceSaveSolution(self % zones(i), mesh, time, iter, FinalName, self % totalFaces(i), &
                                  self % globalFid(1:nf,i), self % faceOffset(1:nf,i), elemSide, &
                                  self % surfaceTypes(i),self % saveGradients, &
-                                 self % mergeFWHandBC, saveUt, saveWtau, saveTurb)
+                                 self % mergeFWHandBC, saveUt, saveUtauVector, saveTurb)
         end do
 !
     End Subroutine SurfSaveAllSolution
@@ -660,7 +660,7 @@ Module SurfaceMesh
 !/////////////////////////////////////////////////////////////////////////////////////////////
 !         
    Subroutine SurfaceSaveSolution(surface_zone, mesh, time, iter, name, no_of_faces, fGlobID, faceOffset, eSides, surface_type, &
-                                  saveGradients, saveBCandFWH, saveUt, saveWtau, saveTurb)
+                                  saveGradients, saveBCandFWH, saveUt, saveUtauVector, saveTurb)
 
 !     *******************************************************************
 !        This subroutine saves the solution from the face storage to a binary file
@@ -680,7 +680,7 @@ Module SurfaceMesh
       character(len=*), intent(in)                         :: name
       integer, dimension(:), intent(in)                    :: fGlobID, faceOffset
       integer, dimension(:), intent(in)                    :: eSides
-      logical                                              :: saveGradients, saveBCandFWH, saveUt, saveWtau, saveTurb
+      logical                                              :: saveGradients, saveBCandFWH, saveUt, saveUtauVector, saveTurb
 
       ! local variables
       integer                                              :: zoneFaceID, meshFaceID, solution_type
@@ -749,7 +749,7 @@ Module SurfaceMesh
 
 #if defined(NAVIERSTOKES)
       if (saveUt) padding = padding + 1
-      if (saveWtau) padding = padding + NDIM
+      if (saveUtauVector) padding = padding + NDIM
       ! save mu_NS and y, for y+ value calc
       if (saveTurb) padding = padding + 2
 #endif
@@ -825,10 +825,10 @@ Module SurfaceMesh
                deallocate(Q)
 #endif
           end if
-          if (saveWtau) then
+          if (saveUtauVector) then
 #if defined(NAVIERSTOKES)
                allocate(Q(1:NDIM,0:Nx,0:Ny))
-               Q(1:NDIM,:,:)= f % storage(eSides(zoneFaceID)) % w_tau_NS(:,:,:)
+               Q(1:NDIM,:,:)= f % storage(eSides(zoneFaceID)) % u_tau_vec_NS(:,:,:)
                write(fid) Q
                deallocate(Q)
 #endif
@@ -1397,7 +1397,7 @@ Module SurfaceMesh
 
 
         if (.not. surfaces % active) return
-        if ((.not. surfaces % saveUt) .and. (.not. surfaces % saveWtau)) return
+        if ((.not. surfaces % saveUt) .and. (.not. surfaces % saveUtauVector)) return
 
         u  = cos(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
         v  = sin(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
@@ -1422,7 +1422,7 @@ Module SurfaceMesh
                            tangent_1 => mesh % faces(meshFaceID) % geom % t1, &
                            tangent_2 => mesh % faces(meshFaceID) % geom % t2, &
                            u_tau => mesh % faces(meshFaceID) % storage(1) % u_tau_NS, &
-                           w_tau => mesh % faces(meshFaceID) % storage(1) % w_tau_NS )
+                           u_tau_vec => mesh % faces(meshFaceID) % storage(1) % u_tau_vec_NS )
                     do j=0,mesh % faces(meshFaceID) % Nf(2)   ; do i = 0, mesh % faces(meshFaceID) % Nf(1)
                         if (surfaces % saveUt) then
                             if (saveUTauWithSign) then
@@ -1433,8 +1433,8 @@ Module SurfaceMesh
                                 u_tau(i,j) = sqrt(u_tau_t1**2+u_tau_t2**2)
                             endif
                         end if
-                        if (surfaces % saveWtau) then
-                            call getWallShearStressVector(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),w_tau(:,i,j))
+                        if (surfaces % saveUtauVector) then
+                            call getFrictionVelocityVector(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),u_tau_vec(:,i,j))
                         end if
                     end do             ; end do
                 end associate

--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -43,6 +43,7 @@ Module SurfaceMesh
         logical                                                 :: mergeFWHandBC    ! flag to merge 2 surfaces if they have the same BCs
         logical                                                 :: active           ! flag use for save at least one file
         logical                                                 :: saveUt           ! flag use for save friction velocity in bcs
+        logical                                                 :: saveWtau         ! flag use for save wall shear stress vector in bcs
         logical                                                 :: saveTurb         ! flag use for save wall normal distance, and viscosity
 
         contains
@@ -130,6 +131,7 @@ Module SurfaceMesh
         sliceTolerance = controlVariables % getValueOrDefault("slice tolerance", 1.0e-4_RP)
         self % saveGradients = controlVariables % logicalValueForKey("surface save gradients") .or. controlVariables % logicalValueForKey("save gradients")
         self % saveUt = controlVariables % logicalValueForKey("surface save utau")
+        self % saveWtau = controlVariables % logicalValueForKey("surface save w_tau")
         self % saveTurb = controlVariables % logicalValueForKey("surface save turbulent")
 !
 !       get number of surfaces
@@ -466,12 +468,13 @@ Module SurfaceMesh
         character(len=LINE_LENGTH)                          :: FinalName      !  Final name for particular file
         logical                                             :: saveFWH
         integer, dimension(:), allocatable                  :: elemSide
-        logical                                             :: saveUt, saveTurb
+        logical                                             :: saveUt, saveWtau, saveTurb
 
         if (.not. self % active) return
         saveFWH = controlVariables % logicalValueForKey("acoustic solution save") .or. self % mergeFWHandBC
         do i = 1, self % numberOfSurfaces
             saveUt = .false.
+            saveWtau = .false.
             saveTurb = .false.
             if (.not. self % surfaceActive(i)) cycle
             !skip fwh if not requested
@@ -491,13 +494,14 @@ Module SurfaceMesh
                  (self % surfaceTypes(i) .eq. SURFACE_TYPE_FWH .and. self % mergeFWHandBC) ) then
                 if (self%isNoSlip(i)) then
                     saveUt = self % saveUt
+                    saveWtau = self % saveWtau
                     saveTurb = self % saveTurb
                 end if
             end if
             call SurfaceSaveSolution(self % zones(i), mesh, time, iter, FinalName, self % totalFaces(i), &
                                  self % globalFid(1:nf,i), self % faceOffset(1:nf,i), elemSide, &
                                  self % surfaceTypes(i),self % saveGradients, &
-                                 self % mergeFWHandBC, saveUt, saveTurb)
+                                 self % mergeFWHandBC, saveUt, saveWtau, saveTurb)
         end do
 !
     End Subroutine SurfSaveAllSolution
@@ -656,7 +660,7 @@ Module SurfaceMesh
 !/////////////////////////////////////////////////////////////////////////////////////////////
 !         
    Subroutine SurfaceSaveSolution(surface_zone, mesh, time, iter, name, no_of_faces, fGlobID, faceOffset, eSides, surface_type, &
-                                  saveGradients, saveBCandFWH, saveUt, saveTurb)
+                                  saveGradients, saveBCandFWH, saveUt, saveWtau, saveTurb)
 
 !     *******************************************************************
 !        This subroutine saves the solution from the face storage to a binary file
@@ -676,7 +680,7 @@ Module SurfaceMesh
       character(len=*), intent(in)                         :: name
       integer, dimension(:), intent(in)                    :: fGlobID, faceOffset
       integer, dimension(:), intent(in)                    :: eSides
-      logical                                              :: saveGradients, saveBCandFWH, saveUt, saveTurb
+      logical                                              :: saveGradients, saveBCandFWH, saveUt, saveWtau, saveTurb
 
       ! local variables
       integer                                              :: zoneFaceID, meshFaceID, solution_type
@@ -744,6 +748,7 @@ Module SurfaceMesh
       end select
 
       if (saveUt) padding = padding + 1
+      if (saveWtau) padding = padding + NDIM
       ! save mu_NS and y, for y+ value calc
       if (saveTurb) padding = padding + 2
 !
@@ -817,7 +822,15 @@ Module SurfaceMesh
                write(fid) Q
                deallocate(Q)
 #endif
-          end if 
+          end if
+          if (saveWtau) then
+#if defined(NAVIERSTOKES)
+               allocate(Q(1:NDIM,0:Nx,0:Ny))
+               Q(1:NDIM,:,:)= f % storage(eSides(zoneFaceID)) % w_tau_NS(:,:,:)
+               write(fid) Q
+               deallocate(Q)
+#endif
+          end if
           if (saveTurb) then
 #if defined(NAVIERSTOKES)
                allocate(Q(1,0:Nx,0:Ny))
@@ -1382,7 +1395,7 @@ Module SurfaceMesh
 
 
         if (.not. surfaces % active) return
-        if (.not. surfaces % saveUt) return
+        if ((.not. surfaces % saveUt) .and. (.not. surfaces % saveWtau)) return
 
         u  = cos(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
         v  = sin(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
@@ -1406,15 +1419,21 @@ Module SurfaceMesh
                            normal => mesh % faces(meshFaceID) % geom % normal, &
                            tangent_1 => mesh % faces(meshFaceID) % geom % t1, &
                            tangent_2 => mesh % faces(meshFaceID) % geom % t2, &
-                           u_tau => mesh % faces(meshFaceID) % storage(1) % u_tau_NS )
+                           u_tau => mesh % faces(meshFaceID) % storage(1) % u_tau_NS, &
+                           w_tau => mesh % faces(meshFaceID) % storage(1) % w_tau_NS )
                     do j=0,mesh % faces(meshFaceID) % Nf(2)   ; do i = 0, mesh % faces(meshFaceID) % Nf(1)
-                        if (saveUTauWithSign) then 
-                            call getFrictionVelocityWithSign(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),tangent_2(:,i,j), freestream_dir, u_tau(i,j))
-                        else 
-                            call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),u_tau_t1)
-                            call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_2(:,i,j),u_tau_t2)
-                            u_tau(i,j) = sqrt(u_tau_t1**2+u_tau_t2**2)
-                        endif 
+                        if (surfaces % saveUt) then
+                            if (saveUTauWithSign) then
+                                call getFrictionVelocityWithSign(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),tangent_2(:,i,j), freestream_dir, u_tau(i,j))
+                            else
+                                call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),u_tau_t1)
+                                call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_2(:,i,j),u_tau_t2)
+                                u_tau(i,j) = sqrt(u_tau_t1**2+u_tau_t2**2)
+                            endif
+                        end if
+                        if (surfaces % saveWtau) then
+                            call getWallShearStressVector(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),w_tau(:,i,j))
+                        end if
                     end do             ; end do
                 end associate
 

--- a/Solver/src/libs/physics/navierstokes/Physics_NS.f90
+++ b/Solver/src/libs/physics/navierstokes/Physics_NS.f90
@@ -34,6 +34,7 @@
       public  GuermondPopovFlux_ENTROPY
       public  InviscidJacobian, ComputeEigenvaluesForState
       public  getStressTensor, ViscousJacobian, getFrictionVelocity, getFrictionVelocityWithSign
+      public  getWallShearStressVector
 !
 !     ========
       CONTAINS 
@@ -910,6 +911,31 @@
          u_tau = sqrt(abs(tau_w) / Q(IRHO)) * sign(1.0_RP, tau_w)
 
       End Subroutine getFrictionVelocity
+
+      Subroutine getWallShearStressVector(Q,Q_x,Q_y,Q_z,normal,w_tau)
+         implicit none
+         real(kind=RP), intent(in)      :: Q   (1:NCONS   )
+         real(kind=RP), intent(in)      :: Q_x (1:NGRAD   )
+         real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
+         real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
+         real(kind=RP), intent(in)      :: normal (1:NDIM )
+         real(kind=RP), intent(out)     :: w_tau (1:NDIM )
+
+!
+!        ---------------
+!        Local variables
+!        ---------------
+!
+         real(kind=RP)                  :: tau (1:NDIM, 1:NDIM   )
+         real(kind=RP)                  :: tau_w_vec(1:NDIM)
+
+         call getStressTensor(Q, Q_x, Q_y, Q_z, tau)
+         tau_w_vec = -1.0_RP * matmul(tau, normal)
+
+         ! keep only the tangential part of the traction vector (remove the wall-normal component)
+         w_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+
+      End Subroutine getWallShearStressVector
 
       !@mark -
 

--- a/Solver/src/libs/physics/navierstokes/Physics_NS.f90
+++ b/Solver/src/libs/physics/navierstokes/Physics_NS.f90
@@ -919,7 +919,7 @@
          real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
          real(kind=RP), intent(in)      :: normal (1:NDIM )
-         real(kind=RP), intent(out)     :: w_tau (1:NDIM )
+         real(kind=RP), intent(out)     :: w_tau (1:NDIM )   ! friction velocity vector (velocity units)
 
 !
 !        ---------------
@@ -928,12 +928,23 @@
 !
          real(kind=RP)                  :: tau (1:NDIM, 1:NDIM   )
          real(kind=RP)                  :: tau_w_vec(1:NDIM)
+         real(kind=RP)                  :: tangential_tau(1:NDIM)
+         real(kind=RP)                  :: tau_w_mag
 
          call getStressTensor(Q, Q_x, Q_y, Q_z, tau)
          tau_w_vec = -1.0_RP * matmul(tau, normal)
 
          ! keep only the tangential part of the traction vector (remove the wall-normal component)
-         w_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+         tangential_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+         tau_w_mag = sqrt(dot_product(tangential_tau, tangential_tau))
+
+         ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
+         ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
+         if ( tau_w_mag > tiny(1.0_RP) ) then
+            w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
+         else
+            w_tau = 0.0_RP
+         end if
 
       End Subroutine getWallShearStressVector
 

--- a/Solver/src/libs/physics/navierstokes/Physics_NS.f90
+++ b/Solver/src/libs/physics/navierstokes/Physics_NS.f90
@@ -34,7 +34,7 @@
       public  GuermondPopovFlux_ENTROPY
       public  InviscidJacobian, ComputeEigenvaluesForState
       public  getStressTensor, ViscousJacobian, getFrictionVelocity, getFrictionVelocityWithSign
-      public  getWallShearStressVector
+      public  getFrictionVelocityVector
 !
 !     ========
       CONTAINS 
@@ -912,14 +912,14 @@
 
       End Subroutine getFrictionVelocity
 
-      Subroutine getWallShearStressVector(Q,Q_x,Q_y,Q_z,normal,w_tau)
+      Subroutine getFrictionVelocityVector(Q,Q_x,Q_y,Q_z,normal,u_tau_vec)
          implicit none
          real(kind=RP), intent(in)      :: Q   (1:NCONS   )
          real(kind=RP), intent(in)      :: Q_x (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
          real(kind=RP), intent(in)      :: normal (1:NDIM )
-         real(kind=RP), intent(out)     :: w_tau (1:NDIM )   ! friction velocity vector (velocity units)
+         real(kind=RP), intent(out)     :: u_tau_vec (1:NDIM )   ! friction velocity vector (velocity units)
 
 !
 !        ---------------
@@ -941,12 +941,12 @@
          ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
          ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
          if ( tau_w_mag > tiny(1.0_RP) .and. Q(IRHO) > tiny(1.0_RP) ) then
-            w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
+            u_tau_vec = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
          else
-            w_tau = 0.0_RP
+            u_tau_vec = 0.0_RP
          end if
 
-      End Subroutine getWallShearStressVector
+      End Subroutine getFrictionVelocityVector
 
       !@mark -
 

--- a/Solver/src/libs/physics/navierstokes/Physics_NS.f90
+++ b/Solver/src/libs/physics/navierstokes/Physics_NS.f90
@@ -940,7 +940,7 @@
 
          ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
          ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
-         if ( tau_w_mag > tiny(1.0_RP) ) then
+         if ( tau_w_mag > tiny(1.0_RP) .and. Q(IRHO) > tiny(1.0_RP) ) then
             w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
          else
             w_tau = 0.0_RP

--- a/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
+++ b/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
@@ -20,7 +20,7 @@
       public  GuermondPopovFlux_ENTROPY
       public  InviscidJacobian
       public  getStressTensor, getFrictionVelocity, getFrictionVelocityWithSign
-      public  getWallShearStressVector
+      public  getFrictionVelocityVector
 !
 !     ========
       CONTAINS 
@@ -679,14 +679,14 @@
 
       End Subroutine getFrictionVelocity
 
-      Subroutine getWallShearStressVector(Q,Q_x,Q_y,Q_z,normal,w_tau)
+      Subroutine getFrictionVelocityVector(Q,Q_x,Q_y,Q_z,normal,u_tau_vec)
          implicit none
          real(kind=RP), intent(in)      :: Q   (1:NCONS   )
          real(kind=RP), intent(in)      :: Q_x (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
          real(kind=RP), intent(in)      :: normal (1:NDIM )
-         real(kind=RP), intent(out)     :: w_tau (1:NDIM )   ! friction velocity vector (velocity units)
+         real(kind=RP), intent(out)     :: u_tau_vec (1:NDIM )   ! friction velocity vector (velocity units)
 
 !
 !        ---------------
@@ -708,12 +708,12 @@
          ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
          ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
          if ( tau_w_mag > tiny(1.0_RP) .and. Q(IRHO) > tiny(1.0_RP) ) then
-            w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
+            u_tau_vec = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
          else
-            w_tau = 0.0_RP
+            u_tau_vec = 0.0_RP
          end if
 
-      End Subroutine getWallShearStressVector
+      End Subroutine getFrictionVelocityVector
 
       Subroutine getFrictionVelocityWithSign(Q,Q_x,Q_y,Q_z,normal,tangent_1,tangent_2,freestream_dir, u_tau)
          implicit none

--- a/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
+++ b/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
@@ -707,7 +707,7 @@
 
          ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
          ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
-         if ( tau_w_mag > tiny(1.0_RP) ) then
+         if ( tau_w_mag > tiny(1.0_RP) .and. Q(IRHO) > tiny(1.0_RP) ) then
             w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
          else
             w_tau = 0.0_RP

--- a/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
+++ b/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
@@ -20,6 +20,7 @@
       public  GuermondPopovFlux_ENTROPY
       public  InviscidJacobian
       public  getStressTensor, getFrictionVelocity, getFrictionVelocityWithSign
+      public  getWallShearStressVector
 !
 !     ========
       CONTAINS 
@@ -677,6 +678,31 @@
          u_tau = sqrt(abs(tau_w) / Q(IRHO)) * sign(1.0_RP, tau_w)
 
       End Subroutine getFrictionVelocity
+
+      Subroutine getWallShearStressVector(Q,Q_x,Q_y,Q_z,normal,w_tau)
+         implicit none
+         real(kind=RP), intent(in)      :: Q   (1:NCONS   )
+         real(kind=RP), intent(in)      :: Q_x (1:NGRAD   )
+         real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
+         real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
+         real(kind=RP), intent(in)      :: normal (1:NDIM )
+         real(kind=RP), intent(out)     :: w_tau (1:NDIM )
+
+!
+!        ---------------
+!        Local variables
+!        ---------------
+!
+         real(kind=RP)                  :: tau (1:NDIM, 1:NDIM   )
+         real(kind=RP)                  :: tau_w_vec(1:NDIM)
+
+         call getStressTensor(Q, Q_x, Q_y, Q_z, tau)
+         tau_w_vec = -1.0_RP * matmul(tau, normal)
+
+         ! keep only the tangential part of the traction vector (remove the wall-normal component)
+         w_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+
+      End Subroutine getWallShearStressVector
 
       Subroutine getFrictionVelocityWithSign(Q,Q_x,Q_y,Q_z,normal,tangent_1,tangent_2,freestream_dir, u_tau)
          implicit none

--- a/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
+++ b/Solver/src/libs/physics/spallartalmaras/Physics_NSSA.f90
@@ -686,7 +686,7 @@
          real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
          real(kind=RP), intent(in)      :: normal (1:NDIM )
-         real(kind=RP), intent(out)     :: w_tau (1:NDIM )
+         real(kind=RP), intent(out)     :: w_tau (1:NDIM )   ! friction velocity vector (velocity units)
 
 !
 !        ---------------
@@ -695,12 +695,23 @@
 !
          real(kind=RP)                  :: tau (1:NDIM, 1:NDIM   )
          real(kind=RP)                  :: tau_w_vec(1:NDIM)
+         real(kind=RP)                  :: tangential_tau(1:NDIM)
+         real(kind=RP)                  :: tau_w_mag
 
          call getStressTensor(Q, Q_x, Q_y, Q_z, tau)
          tau_w_vec = -1.0_RP * matmul(tau, normal)
 
          ! keep only the tangential part of the traction vector (remove the wall-normal component)
-         w_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+         tangential_tau = tau_w_vec - dot_product(tau_w_vec, normal) * normal
+         tau_w_mag = sqrt(dot_product(tangential_tau, tangential_tau))
+
+         ! rescale the (stress-valued) tangential traction into a friction-velocity vector:
+         ! same direction as the wall shear stress, magnitude equal to sqrt(|tau_w|/rho)
+         if ( tau_w_mag > tiny(1.0_RP) ) then
+            w_tau = tangential_tau * sqrt(tau_w_mag / Q(IRHO)) / tau_w_mag
+         else
+            w_tau = 0.0_RP
+         end if
 
       End Subroutine getWallShearStressVector
 

--- a/doc/UserManual.tex
+++ b/doc/UserManual.tex
@@ -1956,6 +1956,115 @@ The options are:
 \end{itemize}
 \end{multicols}
 
+\subsection{Surface Solution Files (*.surf.hsol)} \label{PostProc:surfhsol}
+
+HORSES3D can save the solution restricted to a set of boundaries (instead of the full volume) at a fixed time interval, while the simulation is running. These \textit{surface solution files} are the recommended way of postprocessing wall quantities such as the friction velocity, the wall shear stress, the skin friction coefficient $C_f$ or $y^+$, since they are much smaller than full volume snapshots and can be saved much more frequently.
+
+\subsubsection{Generating surface solution files}
+
+Surface saving is configured entirely from the \textbf{simulation} control file (the one used to run the solver, not the one used by \textit{horses2plt}). The relevant keywords are:
+
+\begin{longtable}{|p{4cm}|p{10cm}|p{2.2cm}|}
+\caption{Keywords for generating surface solution files.} \label{tab:surfacesave} \\
+\hline
+\multicolumn{1}{|c|}{\textbf{Keyword}} & \multicolumn{1}{c|}{\textbf{Description}} & \multicolumn{1}{c|}{\textbf{Default value}} \\ \hline
+\endfirsthead
+
+boundaries to save 	& \textit{ARRAY}: List of boundary marker names for which a surface solution file is generated, e.g. \textit{[cylinder]}. & Not present \\ \hline
+
+surface save timestep 	& \textit{REAL}: Simulation-time interval between surface autosaves. & Not present \\ \hline
+
+surface save gradients 	& \textit{LOGICAL}: Additionally save the velocity gradients ($\partial u_i/\partial x_j$) on the surface. & \textit{.false.} \\ \hline
+
+surface save utau 	& \textit{LOGICAL}: Save the (scalar) friction velocity $u_\tau$ on no-slip walls. & \textit{.false.} \\ \hline
+
+surface save utau vector 	& \textit{LOGICAL}: Save the friction-velocity \textbf{vector} (Cartesian components $u_{\tau,x}, u_{\tau,y}, u_{\tau,z}$) on no-slip walls. & \textit{.false.} \\ \hline
+
+surface save turbulent 	& \textit{LOGICAL}: Save the wall viscosity (\textit{mu\_ns}) and the wall-normal distance (\textit{wall\_distance}), needed for $y^+$. & \textit{.false.} \\ \hline
+\end{longtable}
+
+Only no-slip wall boundaries actually receive the \textit{utau}/\textit{utau vector}/\textit{turbulent} data; the other flags apply to any saved boundary (walls or slices). \textit{surface save utau} and \textit{surface save utau vector} are independent and can both be active at the same time. Example:
+
+\begin{lstlisting}[language=bash]
+boundaries to save       = [cylinder]
+surface save timestep    = 1e-3
+surface save gradients   = .false.
+surface save turbulent   = .true.
+surface save utau        = .true.
+surface save utau vector = .true.
+\end{lstlisting}
+
+\textbf{Important:} these flags only control what gets \textit{written} to the \textit{.surf.hsol} file at solve time. The corresponding \textit{additional variables} flags used by \textit{horses2plt} (see below) only control what it \textit{expects to read} --- they do not create data that was not saved. Requesting a variable in \textit{horses2plt} that was not actually saved by the solver will misalign the reads for every following face and typically causes a crash or an explicit ``Array found in file dimensions does not match...'' error. Always keep the solver's \textit{surface save ...} flags and \textit{horses2plt}'s \textit{additional variables} in sync, and rebuild/rerun the \textbf{solver} binary (not just \textit{horses2plt}) after any code change that affects these fields, since the writing code lives in the shared mesh library.
+
+\subsubsection{Postprocessing surface solution files}
+
+Surface files are postprocessed with the same \textit{horses2plt} tool, pointing it at the surface mesh/solution instead of the volume ones:
+
+\begin{lstlisting}[language=bash]
+hmesh file = "MESH/Cylinder_bc001_0000000000.surf.hmesh"
+hsol file  = "RESULTS/surfaces/Cylinder_bc001_0000000906.surf.hsol"
+\end{lstlisting}
+
+Wall/turbulence-related quantities are not read by default: they must be requested with the \textit{additional variables} keyword, matching what the solver actually saved:
+
+\begin{longtable}{|p{3.2cm}|p{6.5cm}|p{4.5cm}|}
+\caption{\textit{additional variables} tokens for surface postprocessing.} \label{tab:additionalvariables} \\
+\hline
+\multicolumn{1}{|c|}{\textbf{Token}} & \multicolumn{1}{c|}{\textbf{Enables reading}} & \multicolumn{1}{c|}{\textbf{Requires the solver flag(s)}} \\ \hline
+\endfirsthead
+
+u\_tau 	& Scalar friction velocity & surface save utau = .true. \\ \hline
+
+u\_tau\_vector 	& Friction-velocity vector (Cartesian components) & surface save utau vector = .true. \\ \hline
+
+turb 	& Wall viscosity + wall distance (needed for $y^+$) & surface save turbulent = .true. \\ \hline
+
+les 	& Sub-grid viscosity (\textit{mu\_sgs}) & (LES/SGS output, volume files) \\ \hline
+\end{longtable}
+
+\begin{lstlisting}[language=bash]
+additional variables = "[u_tau,u_tau_vector,turb]"
+output variables = Cp, Cf, yplus, wall_distance, u_tau
+\end{lstlisting}
+
+\subsubsection{Wall/turbulence-related output variables}
+
+\begin{multicols}{2}
+\begin{itemize}
+\item $u\_tau$
+\item $u\_tau\_x$
+\item $u\_tau\_y$
+\item $u\_tau\_z$
+\item $wall\_shear$
+\item $Cf$
+\item $yplus$
+\item $wall\_distance$
+\item $mu\_ns$
+\item $mu\_sgs$
+\end{itemize}
+\end{multicols}
+
+\begin{itemize}
+\item \textbf{u\_tau}: friction velocity magnitude, $u_\tau = \sqrt{|\tau_w|/\rho}$ (velocity units). Requires the \textit{u\_tau} additional variable.
+\item \textbf{u\_tau\_x, u\_tau\_y, u\_tau\_z}: Cartesian components of the friction-velocity vector, same velocity units and sign convention as the local wall shear stress direction (unlike the scalar \textit{u\_tau}, which is always reported as a magnitude). By construction, $\sqrt{u\_tau\_x^2+u\_tau\_y^2+u\_tau\_z^2} = u\_tau$. Requires the \textit{u\_tau\_vector} additional variable.
+\item \textbf{Requesting \textit{u\_tau} as an output variable is context-dependent}: asking for \textit{output variables = ... u\_tau ...} does \textbf{not} always produce a single column --- it expands automatically depending on which additional variables were activated:
+  \begin{itemize}
+  \item only \textit{u\_tau} active $\rightarrow$ 1 column: \textit{u\_tau}.
+  \item only \textit{u\_tau\_vector} active $\rightarrow$ 3 columns: \textit{u\_tau\_x, u\_tau\_y, u\_tau\_z}.
+  \item both active $\rightarrow$ 4 columns: \textit{u\_tau, u\_tau\_x, u\_tau\_y, u\_tau\_z}.
+  \end{itemize}
+  There is no separate \textit{u\_tau\_vector} output variable to request; the single \textit{u\_tau} key covers every combination.
+\item \textbf{wall\_shear}: wall shear stress $\tau_w = \rho\,u_\tau^2\,\text{sign}(u_\tau)$ (stress units). Requires \textit{u\_tau}.
+\item \textbf{Cf}: skin friction coefficient, $C_f = 2\,\tau_w$ in the code's reference-normalized nondimensional units, equivalent to the standard definition $C_f = \tau_w/(\tfrac{1}{2}\rho_\infty U_\infty^2)$. Requires \textit{u\_tau}. This is \textbf{not} algebraically the same as reconstructing \textit{Cf} from \textit{u\_tau}/\textit{u\_tau\_x/y/z} divided by a reference velocity (that reintroduces the \textit{local} density instead of the reference one --- see the discussion below).
+\item \textbf{yplus}: wall-normal distance in wall units. Requires \textit{u\_tau} and \textit{turb}.
+\item \textbf{wall\_distance}: distance from the first fluid solution point to the wall. Requires \textit{turb}.
+\item \textbf{mu\_ns}: molecular (+ SGS, if LES) viscosity at the wall. Requires \textit{turb} or \textit{les}.
+\end{itemize}
+
+\paragraph{Cf vs. a manual u\_tau-based reconstruction}
+
+Because $u_\tau$ is defined using the \textbf{local} density, $u_\tau=\sqrt{|\tau_w|/\rho_{local}}$, reconstructing a skin friction coefficient by hand as \textit{2*(u\_tau/U\_ref)\textasciicircum2} (e.g. in ParaView, from \textit{u\_tau} or \textit{sqrt(u\_tau\_x\textasciicircum2+u\_tau\_y\textasciicircum2+u\_tau\_z\textasciicircum2)}) computes $2\,\tau_w/\rho_{local}$, \textbf{not} the standard $C_f = 2\,\tau_w/\rho_\infty$ that the \textit{Cf} output variable already provides directly. The two only coincide where $\rho_{local}\approx\rho_\infty$, and can differ substantially in regions with strong local compressibility effects (e.g. across a shock, or a stagnation point). Prefer the \textit{Cf} output variable over a manual reconstruction unless you specifically need it normalized by the local density (e.g. to compare against another code that itself uses that convention).
+
 \subsection{Statistics Files (*.stats.hsol)}
 Statistics files can generate the standard variables as well as the following variables (being $S_{ij}$ the components of the Reynolds Stress tensor):
 

--- a/doc/basicManualAndTutorial.tex
+++ b/doc/basicManualAndTutorial.tex
@@ -608,6 +608,115 @@ The options are:
 \end{itemize}
 \end{multicols}
 
+\subsection{Surface Solution Files (*.surf.hsol)} \label{PostProc:surfhsol}
+
+HORSES3D can save the solution restricted to a set of boundaries (instead of the full volume) at a fixed time interval, while the simulation is running. These \textit{surface solution files} are the recommended way of postprocessing wall quantities such as the friction velocity, the wall shear stress, the skin friction coefficient $C_f$ or $y^+$, since they are much smaller than full volume snapshots and can be saved much more frequently.
+
+\subsubsection{Generating surface solution files}
+
+Surface saving is configured entirely from the \textbf{simulation} control file (the one used to run the solver, not the one used by \textit{horses2plt}). The relevant keywords are:
+
+\begin{longtable}{|p{4cm}|p{10cm}|p{2.2cm}|}
+\caption{Keywords for generating surface solution files.} \label{tab:surfacesave} \\
+\hline
+\multicolumn{1}{|c|}{\textbf{Keyword}} & \multicolumn{1}{c|}{\textbf{Description}} & \multicolumn{1}{c|}{\textbf{Default value}} \\ \hline
+\endfirsthead
+
+boundaries to save 	& \textit{ARRAY}: List of boundary marker names for which a surface solution file is generated, e.g. \textit{[cylinder]}. & Not present \\ \hline
+
+surface save timestep 	& \textit{REAL}: Simulation-time interval between surface autosaves. & Not present \\ \hline
+
+surface save gradients 	& \textit{LOGICAL}: Additionally save the velocity gradients ($\partial u_i/\partial x_j$) on the surface. & \textit{.false.} \\ \hline
+
+surface save utau 	& \textit{LOGICAL}: Save the (scalar) friction velocity $u_\tau$ on no-slip walls. & \textit{.false.} \\ \hline
+
+surface save utau vector 	& \textit{LOGICAL}: Save the friction-velocity \textbf{vector} (Cartesian components $u_{\tau,x}, u_{\tau,y}, u_{\tau,z}$) on no-slip walls. & \textit{.false.} \\ \hline
+
+surface save turbulent 	& \textit{LOGICAL}: Save the wall viscosity (\textit{mu\_ns}) and the wall-normal distance (\textit{wall\_distance}), needed for $y^+$. & \textit{.false.} \\ \hline
+\end{longtable}
+
+Only no-slip wall boundaries actually receive the \textit{utau}/\textit{utau vector}/\textit{turbulent} data; the other flags apply to any saved boundary (walls or slices). \textit{surface save utau} and \textit{surface save utau vector} are independent and can both be active at the same time. Example:
+
+\begin{lstlisting}[language=bash]
+boundaries to save       = [cylinder]
+surface save timestep    = 1e-3
+surface save gradients   = .false.
+surface save turbulent   = .true.
+surface save utau        = .true.
+surface save utau vector = .true.
+\end{lstlisting}
+
+\textbf{Important:} these flags only control what gets \textit{written} to the \textit{.surf.hsol} file at solve time. The corresponding \textit{additional variables} flags used by \textit{horses2plt} (see below) only control what it \textit{expects to read} --- they do not create data that was not saved. Requesting a variable in \textit{horses2plt} that was not actually saved by the solver will misalign the reads for every following face and typically causes a crash or an explicit ``Array found in file dimensions does not match...'' error. Always keep the solver's \textit{surface save ...} flags and \textit{horses2plt}'s \textit{additional variables} in sync, and rebuild/rerun the \textbf{solver} binary (not just \textit{horses2plt}) after any code change that affects these fields, since the writing code lives in the shared mesh library.
+
+\subsubsection{Postprocessing surface solution files}
+
+Surface files are postprocessed with the same \textit{horses2plt} tool, pointing it at the surface mesh/solution instead of the volume ones:
+
+\begin{lstlisting}[language=bash]
+hmesh file = "MESH/Cylinder_bc001_0000000000.surf.hmesh"
+hsol file  = "RESULTS/surfaces/Cylinder_bc001_0000000906.surf.hsol"
+\end{lstlisting}
+
+Wall/turbulence-related quantities are not read by default: they must be requested with the \textit{additional variables} keyword, matching what the solver actually saved:
+
+\begin{longtable}{|p{3.2cm}|p{6.5cm}|p{4.5cm}|}
+\caption{\textit{additional variables} tokens for surface postprocessing.} \label{tab:additionalvariables} \\
+\hline
+\multicolumn{1}{|c|}{\textbf{Token}} & \multicolumn{1}{c|}{\textbf{Enables reading}} & \multicolumn{1}{c|}{\textbf{Requires the solver flag(s)}} \\ \hline
+\endfirsthead
+
+u\_tau 	& Scalar friction velocity & surface save utau = .true. \\ \hline
+
+u\_tau\_vector 	& Friction-velocity vector (Cartesian components) & surface save utau vector = .true. \\ \hline
+
+turb 	& Wall viscosity + wall distance (needed for $y^+$) & surface save turbulent = .true. \\ \hline
+
+les 	& Sub-grid viscosity (\textit{mu\_sgs}) & (LES/SGS output, volume files) \\ \hline
+\end{longtable}
+
+\begin{lstlisting}[language=bash]
+additional variables = "[u_tau,u_tau_vector,turb]"
+output variables = Cp, Cf, yplus, wall_distance, u_tau
+\end{lstlisting}
+
+\subsubsection{Wall/turbulence-related output variables}
+
+\begin{multicols}{2}
+\begin{itemize}
+\item $u\_tau$
+\item $u\_tau\_x$
+\item $u\_tau\_y$
+\item $u\_tau\_z$
+\item $wall\_shear$
+\item $Cf$
+\item $yplus$
+\item $wall\_distance$
+\item $mu\_ns$
+\item $mu\_sgs$
+\end{itemize}
+\end{multicols}
+
+\begin{itemize}
+\item \textbf{u\_tau}: friction velocity magnitude, $u_\tau = \sqrt{|\tau_w|/\rho}$ (velocity units). Requires the \textit{u\_tau} additional variable.
+\item \textbf{u\_tau\_x, u\_tau\_y, u\_tau\_z}: Cartesian components of the friction-velocity vector, same velocity units and sign convention as the local wall shear stress direction (unlike the scalar \textit{u\_tau}, which is always reported as a magnitude). By construction, $\sqrt{u\_tau\_x^2+u\_tau\_y^2+u\_tau\_z^2} = u\_tau$. Requires the \textit{u\_tau\_vector} additional variable.
+\item \textbf{Requesting \textit{u\_tau} as an output variable is context-dependent}: asking for \textit{output variables = ... u\_tau ...} does \textbf{not} always produce a single column --- it expands automatically depending on which additional variables were activated:
+  \begin{itemize}
+  \item only \textit{u\_tau} active $\rightarrow$ 1 column: \textit{u\_tau}.
+  \item only \textit{u\_tau\_vector} active $\rightarrow$ 3 columns: \textit{u\_tau\_x, u\_tau\_y, u\_tau\_z}.
+  \item both active $\rightarrow$ 4 columns: \textit{u\_tau, u\_tau\_x, u\_tau\_y, u\_tau\_z}.
+  \end{itemize}
+  There is no separate \textit{u\_tau\_vector} output variable to request; the single \textit{u\_tau} key covers every combination.
+\item \textbf{wall\_shear}: wall shear stress $\tau_w = \rho\,u_\tau^2\,\text{sign}(u_\tau)$ (stress units). Requires \textit{u\_tau}.
+\item \textbf{Cf}: skin friction coefficient, $C_f = 2\,\tau_w$ in the code's reference-normalized nondimensional units, equivalent to the standard definition $C_f = \tau_w/(\tfrac{1}{2}\rho_\infty U_\infty^2)$. Requires \textit{u\_tau}. This is \textbf{not} algebraically the same as reconstructing \textit{Cf} from \textit{u\_tau}/\textit{u\_tau\_x/y/z} divided by a reference velocity (that reintroduces the \textit{local} density instead of the reference one --- see the discussion below).
+\item \textbf{yplus}: wall-normal distance in wall units. Requires \textit{u\_tau} and \textit{turb}.
+\item \textbf{wall\_distance}: distance from the first fluid solution point to the wall. Requires \textit{turb}.
+\item \textbf{mu\_ns}: molecular (+ SGS, if LES) viscosity at the wall. Requires \textit{turb} or \textit{les}.
+\end{itemize}
+
+\paragraph{Cf vs. a manual u\_tau-based reconstruction}
+
+Because $u_\tau$ is defined using the \textbf{local} density, $u_\tau=\sqrt{|\tau_w|/\rho_{local}}$, reconstructing a skin friction coefficient by hand as \textit{2*(u\_tau/U\_ref)\textasciicircum2} (e.g. in ParaView, from \textit{u\_tau} or \textit{sqrt(u\_tau\_x\textasciicircum2+u\_tau\_y\textasciicircum2+u\_tau\_z\textasciicircum2)}) computes $2\,\tau_w/\rho_{local}$, \textbf{not} the standard $C_f = 2\,\tau_w/\rho_\infty$ that the \textit{Cf} output variable already provides directly. The two only coincide where $\rho_{local}\approx\rho_\infty$, and can differ substantially in regions with strong local compressibility effects (e.g. across a shock, or a stagnation point). Prefer the \textit{Cf} output variable over a manual reconstruction unless you specifically need it normalized by the local density (e.g. to compare against another code that itself uses that convention).
+
 \subsection{Statistics Files (*.stats.hsol)}
 Statistics files generate following variables by default (being Sij the components of the Reynolds Stress tensor):
 

--- a/doc/pages/user_manual/s-postprocessing.md
+++ b/doc/pages/user_manual/s-postprocessing.md
@@ -90,6 +90,94 @@ The options are:
 </div>
 
 
+## Surface Solution Files (*.surf.hsol)
+
+`HORSES3D` can save the solution restricted to a set of boundaries (instead of the full volume) at a fixed time interval, while the simulation is running. These *surface solution files* are the recommended way of postprocessing wall quantities such as the friction velocity, the wall shear stress, the skin friction coefficient \(C_f\) or \(y^+\), since they are much smaller than full volume snapshots and can be saved much more frequently.
+
+### Generating surface solution files
+
+Surface saving is configured entirely from the **simulation** control file (the one used to run the solver, not the one used by *horses2plt*). The relevant keywords are:
+
+| Keyword                        | Description                                                                                                                     | Default value |
+|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `boundaries to save`            | *ARRAY*: List of boundary marker names for which a surface solution file is generated, e.g. `[cylinder]`.                        | Not present   |
+| `surface save timestep`         | *REAL*: Simulation-time interval between surface autosaves.                                                                      | Not present   |
+| `surface save gradients`        | *LOGICAL*: Additionally save the velocity gradients (\(\partial u_i/\partial x_j\)) on the surface.                              | `.false.`     |
+| `surface save utau`             | *LOGICAL*: Save the (scalar) friction velocity \(u_\tau\) on no-slip walls.                                                      | `.false.`     |
+| `surface save utau vector`      | *LOGICAL*: Save the friction-velocity **vector** (Cartesian components \(u_{\tau,x}, u_{\tau,y}, u_{\tau,z}\)) on no-slip walls. | `.false.`     |
+| `surface save turbulent`        | *LOGICAL*: Save the wall viscosity (`mu_ns`) and the wall-normal distance (`wall_distance`), needed for \(y^+\).                 | `.false.`     |
+
+Only no-slip wall boundaries actually receive the `utau`/`utau vector`/`turbulent` data; the other flags apply to any saved boundary (walls or slices). `surface save utau` and `surface save utau vector` are independent and can both be active at the same time. Example:
+
+```
+boundaries to save       = [cylinder]
+surface save timestep    = 1e-3
+surface save gradients   = .false.
+surface save turbulent   = .true.
+surface save utau        = .true.
+surface save utau vector = .true.
+```
+
+**Important:** these flags only control what gets *written* to the `.surf.hsol` file at solve time. The corresponding `additional variables` flags used by *horses2plt* (see below) only control what it *expects to read* — they do not create data that was not saved. Requesting a variable in *horses2plt* that was not actually saved by the solver will misalign the reads for every following face and typically causes a crash or an explicit "Array found in file dimensions does not match..." error. Always keep the solver's `surface save ...` flags and *horses2plt*'s `additional variables` in sync, and rebuild/rerun the **solver** binary (not just *horses2plt*) after any code change that affects these fields, since the writing code lives in the shared mesh library.
+
+### Postprocessing surface solution files
+
+Surface files are postprocessed with the same *horses2plt* tool, pointing it at the surface mesh/solution instead of the volume ones:
+
+```
+hmesh file = "MESH/Cylinder_bc001_0000000000.surf.hmesh"
+hsol file  = "RESULTS/surfaces/Cylinder_bc001_0000000906.surf.hsol"
+```
+
+Wall/turbulence-related quantities are not read by default: they must be requested with the `additional variables` keyword, matching what the solver actually saved:
+
+| `additional variables` token | Enables reading                                   | Requires the solver flag(s)                          |
+|-------------------------------|----------------------------------------------------|-------------------------------------------------------|
+| `u_tau`                       | Scalar friction velocity                           | `surface save utau = .true.`                           |
+| `u_tau_vector`                 | Friction-velocity vector (Cartesian components)    | `surface save utau vector = .true.`                    |
+| `turb`                         | Wall viscosity + wall distance (needed for \(y^+\)) | `surface save turbulent = .true.`                      |
+| `les`                          | Sub-grid viscosity (`mu_sgs`)                       | (LES/SGS output, volume files)                          |
+
+```
+additional variables = "[u_tau,u_tau_vector,turb]"
+output variables = Cp, Cf, yplus, wall_distance, u_tau
+```
+
+### Wall/turbulence-related output variables
+
+<div class="multicols" style="column-count: 2;">
+  <ul>
+    <li>\(u\_tau\)</li>
+    <li>\(u\_tau\_x\)</li>
+    <li>\(u\_tau\_y\)</li>
+    <li>\(u\_tau\_z\)</li>
+    <li>\(wall\_shear\)</li>
+    <li>\(Cf\)</li>
+    <li>\(yplus\)</li>
+    <li>\(wall\_distance\)</li>
+    <li>\(mu\_ns\)</li>
+    <li>\(mu\_sgs\)</li>
+  </ul>
+</div>
+
+- **`u_tau`**: friction velocity magnitude, \(u_\tau = \sqrt{|\tau_w|/\rho}\) (velocity units). Requires the `u_tau` additional variable.
+- **`u_tau_x`, `u_tau_y`, `u_tau_z`**: Cartesian components of the friction-velocity vector, same velocity units and sign convention as the local wall shear stress direction (unlike the scalar `u_tau`, which is always reported as a magnitude). By construction, \(\sqrt{u\_tau\_x^2+u\_tau\_y^2+u\_tau\_z^2} = u\_tau\). Requires the `u_tau_vector` additional variable.
+- **Requesting `u_tau` as an output variable is context-dependent**: asking for `output variables = ... u_tau ...` does **not** always produce a single column — it expands automatically depending on which additional variables were activated:
+    - only `u_tau` active &rarr; 1 column: `u_tau`.
+    - only `u_tau_vector` active &rarr; 3 columns: `u_tau_x, u_tau_y, u_tau_z`.
+    - both active &rarr; 4 columns: `u_tau, u_tau_x, u_tau_y, u_tau_z`.
+
+  There is no separate `u_tau_vector` output variable to request; the single `u_tau` key covers every combination.
+- **`wall_shear`**: wall shear stress \(\tau_w = \rho\,u_\tau^2\,\text{sign}(u_\tau)\) (stress units). Requires `u_tau`.
+- **`Cf`**: skin friction coefficient, \(C_f = 2\,\tau_w\) in the code's reference-normalized nondimensional units, equivalent to the standard definition \(C_f = \tau_w/(\tfrac{1}{2}\rho_\infty U_\infty^2)\). Requires `u_tau`. This is **not** algebraically the same as reconstructing `Cf` from `u_tau`/`u_tau_x/y/z` divided by a reference velocity (that reintroduces the *local* density instead of the reference one — see the discussion below).
+- **`yplus`**: wall-normal distance in wall units. Requires `u_tau` and `turb`.
+- **`wall_distance`**: distance from the first fluid solution point to the wall. Requires `turb`.
+- **`mu_ns`**: molecular (+ SGS, if LES) viscosity at the wall. Requires `turb` or `les`.
+
+#### `Cf` vs. a manual `u_tau`-based reconstruction
+
+Because \(u_\tau\) is defined using the **local** density, \(u_\tau=\sqrt{|\tau_w|/\rho_{local}}\), reconstructing a skin friction coefficient by hand as `2*(u_tau/U_ref)^2` (e.g. in ParaView, from `u_tau` or `sqrt(u_tau_x^2+u_tau_y^2+u_tau_z^2)`) computes \(2\,\tau_w/\rho_{local}\), **not** the standard \(C_f = 2\,\tau_w/\rho_\infty\) that the `Cf` output variable already provides directly. The two only coincide where \(\rho_{local}\approx\rho_\infty\), and can differ substantially in regions with strong local compressibility effects (e.g. across a shock, or a stagnation point). Prefer the `Cf` output variable over a manual reconstruction unless you specifically need it normalized by the local density (e.g. to compare against another code that itself uses that convention).
+
 ## Statistics Files (*.stats.hsol)
 Statistics files can generate the standard variables as well as the following variables (being \(S_{ij}\) the components of the Reynolds Stress tensor):
 


### PR DESCRIPTION
## Summary

- Add a friction-velocity **vector** (Cartesian components) computed at no-slip walls, alongside the existing scalar `u_tau`, for surface solution files (`.surf.hsol`).
- New solver control-file flag `surface save utau vector = .true.` writes the vector to the surface solution file, independently of the existing `surface save utau` (scalar).
- `horses2plt`'s existing `u_tau` output variable now expands automatically to 1, 3, or 4 columns depending on which of `u_tau` / `u_tau_vector` were requested in `additional variables` (no new separate output-variable name was introduced, by request).
- Document the new feature (solver flags, `horses2plt` flags, output variables, and units/formulas) in the Markdown and both LaTeX user manuals.

## Motivation

`horses2plt` could previously only export the wall shear stress as a signed scalar magnitude (`u_tau`), derived from a two-tangent decomposition of the wall shear stress. There was no way to recover the directional (Cartesian) components of the wall shear stress for existing or new surface solution files. This adds that capability by computing the friction-velocity vector directly at solve time (from the in-memory velocity gradients already available during the viscous RHS evaluation — no additional gradient-saving is required), storing it per wall face point, and exposing it through `horses2plt`.

## Implementation

**Physics (`Physics_NS.f90`, `Physics_NSSA.f90`)**
- New `getWallShearStressVector(Q,Q_x,Q_y,Q_z,normal,w_tau)`: computes the tangential viscous traction vector (projecting out the wall-normal component of `-tau·n`), then rescales it to a friction-velocity vector with the same direction and magnitude `sqrt(|tau_w|/rho)` — i.e. velocity units, consistent with the existing scalar `u_tau`, rather than stress units.

**Mesh/solver (`StorageClass.f90`, `SurfaceMesh.f90`)**
- New per-face-point storage field `w_tau_NS` (Cartesian vector), mirroring the existing `u_tau_NS` (scalar).
- New `saveWtau` flag / `surface save utau vector` control keyword, independent of `surface save utau`.
- `getU_tauInSurfaces` now also fills `w_tau_NS` when the new flag is active; `SurfaceSaveSolution` writes it to the `.surf.hsol` file (padding grows by `NDIM` reals per point when active).

**Postprocessing (`horses2tecplot` addon: `Storage.f90`, `getTask.f90`, `OutputVariables.f90`)**
- New `hasWtau_NS` flag, driven by `additional variables = "[u_tau_vector]"`.
- Requesting `output variables = u_tau` now expands to:
  - 1 column (`u_tau`) if only the scalar was saved/requested,
  - 3 columns (`u_tau_x, u_tau_y, u_tau_z`) if only the vector was saved/requested,
  - 4 columns (`u_tau, u_tau_x, u_tau_y, u_tau_z`) if both were saved/requested.

**Documentation**
- New "Surface Solution Files (\*.surf.hsol)" section added to `doc/pages/user_manual/s-postprocessing.md`, `doc/UserManual.tex`, and `doc/basicManualAndTutorial.tex`: the solver-side `surface save ...` flags, the `horses2plt` `additional variables` tokens they correspond to, the wall/turbulence output variables (`u_tau`, `u_tau_x/y/z`, `wall_shear`, `Cf`, `yplus`, `wall_distance`, `mu_ns`), and a note on why reconstructing `Cf` manually from `u_tau` (local density) differs from the `Cf` output variable (reference-density-normalized, matching the standard literature definition).
